### PR TITLE
fix RGB light hanrdware settings as split keyboard

### DIFF
--- a/qmk_firmware/keyboards/keyball/keymaps/TBscroll/config.h
+++ b/qmk_firmware/keyboards/keyball/keymaps/TBscroll/config.h
@@ -58,9 +58,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #ifdef RGBLIGHT_ENABLE
-    #undef RGBLED_NUM
 //    #define RGBLIGHT_ANIMATIONS
-    #define RGBLED_NUM 7
     #define RGBLIGHT_LIMIT_VAL 120
     #define RGBLIGHT_HUE_STEP 10
     #define RGBLIGHT_SAT_STEP 17
@@ -68,4 +66,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 
 #define OLED_FONT_H "keyboards/claw44/lib/glcdfont.c"
-

--- a/qmk_firmware/keyboards/keyball/keymaps/default/config.h
+++ b/qmk_firmware/keyboards/keyball/keymaps/default/config.h
@@ -33,9 +33,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define SOFT_SERIAL_PIN D2
 
 #ifdef RGBLIGHT_ENABLE
-    #undef RGBLED_NUM
 //    #define RGBLIGHT_ANIMATIONS
-    #define RGBLED_NUM 7
     #define RGBLIGHT_LIMIT_VAL 120
     #define RGBLIGHT_HUE_STEP 10
     #define RGBLIGHT_SAT_STEP 17
@@ -43,4 +41,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 
 #define OLED_FONT_H "keyboards/keyball/lib/glcdfont.c"
-

--- a/qmk_firmware/keyboards/keyball/keymaps/via/config.h
+++ b/qmk_firmware/keyboards/keyball/keymaps/via/config.h
@@ -33,9 +33,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define SOFT_SERIAL_PIN D2
 
 #ifdef RGBLIGHT_ENABLE
-    #undef RGBLED_NUM
 //    #define RGBLIGHT_ANIMATIONS
-    #define RGBLED_NUM 7
     #define RGBLIGHT_LIMIT_VAL 120
     #define RGBLIGHT_HUE_STEP 10
     #define RGBLIGHT_SAT_STEP 17
@@ -43,4 +41,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 
 #define OLED_FONT_H "keyboards/keyball/lib/glcdfont.c"
-

--- a/qmk_firmware/keyboards/keyball/keymaps/via_Left/config.h
+++ b/qmk_firmware/keyboards/keyball/keymaps/via_Left/config.h
@@ -33,9 +33,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define SOFT_SERIAL_PIN D2
 
 #ifdef RGBLIGHT_ENABLE
-    #undef RGBLED_NUM
 //    #define RGBLIGHT_ANIMATIONS
-    #define RGBLED_NUM 7
     #define RGBLIGHT_LIMIT_VAL 120
     #define RGBLIGHT_HUE_STEP 10
     #define RGBLIGHT_SAT_STEP 17
@@ -43,4 +41,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 
 #define OLED_FONT_H "keyboards/keyball/lib/glcdfont.c"
-

--- a/qmk_firmware/keyboards/keyball/rev1/config.h
+++ b/qmk_firmware/keyboards/keyball/rev1/config.h
@@ -53,9 +53,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define RGB_DI_PIN D3
 
+// RGB Light settings for Keyball46 hardware
 #ifdef RGBLIGHT_ENABLE
-#define RGBLED_NUM 7    // Number of LEDs
-#define RGBLIGHT_SPLIT
+#    define RGBLED_NUM 14    // Number of LEDs
+#    define RGBLED_SPLIT { 7, 7 }
 #endif
 
 /*


### PR DESCRIPTION
RGB Light用の設定がQMKの期待しているものではなかったので修正しました。
修正内容は以下の通りです。

*  RGB Ligth 機能の設定 split キーボード用の方法へ修正しました
    * `RGBLED_NUM` には 両手を合わせた `14` とする
    * `RGBLED_SPLIT` を `{ 7, 7 }` に設定する
    * `RGBLIGHT_SPLIT` は `RGBLED_SPLIT` を設定すれば自動で設定されるので不要 ([参照](https://github.com/qmk/qmk_firmware/blob/dfcefc2d5d05272c63ed8d5d0e7627c2ff5eacec/quantum/rgblight_post_config.h#L1-L4))

    こうすることでSNAKEのようなキーボード全体を対象としたイルミネーションがQMKの期待するように表示されます。たとえばSNAKEであれば、元の設定では両手に同時に2匹の蛇が描画されるのに対し、修正後は1匹だけが表示されこちらがQMK本来の挙動です。

* Keyball46のハードウェアに由来するRGB LEDの設定(`RGBLED_NUM` および `RGBLED_SPLIT`) は rev1/config.h の中にだけ書くようにしました。

    keyball/rev1にはハードウェアにより決まる設定を、keymapsにはキーマップ毎の設定を書くものです。`RGBLED_NUM` 等は明らかにハードウェアで決まるものですので、そちらに移動しkeymaps下での設定は削除しました。

* `#ifdef` 内のインデント表記の一部を訂正しました

   QMKでは `#ifdef` 内の `#define` を `    #define ...` ではなく `#    define` で書くことになっています。それにあわせて一部を訂正しました。以下 https://beta.docs.qmk.fm/developing-qmk/c-development/coding_conventions_c より抜粋

    > When indenting, keep the hash at the start of the line and add whitespace between # and if, starting with 4 spaces after the #.

* ファイル末尾の空行を削除しました

    特に根拠はありませんがあまり見ない作法だったため、今回変更したファイルだけ修正しました。