### PR TITLE
pick up very slow/small rotation which dropped by division

### DIFF
--- a/qmk_firmware/keyboards/keyball/rev1/features_ja.md
+++ b/qmk_firmware/keyboards/keyball/rev1/features_ja.md
@@ -38,20 +38,23 @@ Keyballに付属のデフォルトのトラックボールドライバーを無�
 各キーマップの config.h で設定できます。デフォルトは `10` で `0` 以下の値を設定
 するとコンパイルエラーになります。
 
-### `trackball_process_delta_user()`
+### `trackball_process_user()`
 
-`trackball_process_delta_user()` 関数を定義するとトラックボールの移動量をどのよ
-うに扱うかをユーザーがカスタマイズできます。`trackball_process_delta_user()` は
+`trackball_process_user()` 関数を定義するとトラックボールの移動量をどのよ
+うに扱うかをユーザーがカスタマイズできます。`trackball_process_user()` は
 ドライバーがトラックボールの移動を検知した際に、その移動量を引数にして呼び出し
 ます。ユーザーはポインティングデバイスとしてレポートを送っても良いですし、それ
 以外のことをしてもかまいません。
+
+スクロールモードが有効な場合、渡される移動量は `TRACKBALL_SCROLL_DIVIDER` を考
+慮した値になります。
 
 各キーマップの keymap.c で定義できます。
 
 定義例: マウスカーソルに上下反転させて適用する
 
 ```c
-void trackball_process_delta_user(int8_t dx, int8_t dy) {
+void trackball_process_user(int8_t dx, int8_t dy) {
     report_mouse_t r = pointing_device_get_report();
     r.x = -dx;
     r.y = -dy;

--- a/qmk_firmware/keyboards/keyball/rev1/trackball.c
+++ b/qmk_firmware/keyboards/keyball/rev1/trackball.c
@@ -38,57 +38,78 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    error "TRACKBALL_SCROLL_DIVIDER should be larger than zero"
 #endif
 
+static bool trackball_has(void) {
+    // FIXME: support for secondary.
+    return is_keyboard_master();
+}
+
 __attribute__((weak)) void pointing_device_init(void) {
-    if (is_keyboard_master()){
+    if (trackball_has()){
         optical_sensor_init();
     }
 }
 
-static bool is_scroll_mode;
+static bool is_scroll_mode = false;
 
-static int8_t clamp(int16_t value) {
-    return value < -128 ? -128 : value > 127 ? 127 : (int8_t)value;
+static int16_t accum_count = 0;
+static int16_t accum_x = 0;
+static int16_t accum_y = 0;
+
+// clip2int8 clips an integer fit into int8_t.
+static inline int8_t clip2int8(int16_t v) {
+    return (v) < -128 ? -128 : (v) > 127 ? 127 : (int8_t)v;
+}
+
+// add16 adds two int16_t with clipping.
+static int16_t add16(int16_t a, int16_t b) {
+    int16_t r = a + b;
+    if (a >= 0 && b >= 0 && r < 0) {
+        r = 32767;
+    } else if (a < 0 && b < 0 && r >= 0) {
+        r = -32768;
+    }
+    return r;
 }
 
 __attribute__((weak)) void pointing_device_task(void) {
-    // TODO: support for secondary.
-    if (!is_keyboard_master())
+    if (!trackball_has())
         return;
 
     // Trackball uses mean value of N samples from optical sensor as delta for
     // mouse cursor or scroll.  Number of samples are determined by
     // TRACKBALL_SAMPLE_COUNT.
-
-    static int16_t accum_count = 0;
-    static int16_t accum_x = 0, accum_y = 0;
-
-    report_optical_sensor_t sensor_report = optical_sensor_get_report();
-    accum_x += sensor_report.x;
-    // sensor returns negative values for downward rotation, but screen has
+    //
+    // The sensor returns negative values for downward rotation, but screen has
     // positive axis for downward, so we invert the sign of Y.
-    accum_y -= sensor_report.y;
+    report_optical_sensor_t sensor_report = optical_sensor_get_report();
+    accum_x = add16(accum_x, sensor_report.x);
+    accum_y = add16(accum_y, -sensor_report.y);
     accum_count++;
 
     if (accum_count >= TRACKBALL_SAMPLE_COUNT) {
-        int8_t dx = clamp(accum_x / accum_count);
-        int8_t dy = clamp(accum_y / accum_count);
+        // divice to calculate mean value and clip it to fit into int8_t.
+        int16_t div = is_scroll_mode ? TRACKBALL_SAMPLE_COUNT * TRACKBALL_SCROLL_DIVIDER : TRACKBALL_SAMPLE_COUNT;
+        int8_t dx = clip2int8(accum_x / div);
+        int8_t dy = clip2int8(accum_y / div);
+        // process delta.
         if (dx != 0 || dy != 0) {
-            trackball_process_delta_user(dx, dy);
+            // FIXME: transport the event to primary if I am secondary.
+            trackball_process_user(dx, dy);
         }
-        // clear accumulation variables.
-        accum_x = 0;
-        accum_y = 0;
+        // clear accumulators with considering surplus.
+        accum_x %= div;
+        accum_y %= div;
         accum_count = 0;
     }
 
     pointing_device_send();
 }
 
-__attribute__((weak)) void trackball_process_delta_user(int8_t dx, int8_t dy) {
+__attribute__((weak)) void trackball_process_user(int8_t dx, int8_t dy) {
     report_mouse_t r = pointing_device_get_report();
     if (is_scroll_mode) {
-        r.h = dx / TRACKBALL_SCROLL_DIVIDER;
-        r.v = -dy / TRACKBALL_SCROLL_DIVIDER;
+        r.h = dx;
+        r.v = -dy;
     } else {
         r.x = dx;
         r.y = dy;
@@ -101,7 +122,13 @@ bool trackball_get_scroll_mode(void) {
 }
 
 void trackball_set_scroll_mode(bool mode) {
-    is_scroll_mode = mode;
+    if (is_scroll_mode != mode) {
+        is_scroll_mode = mode;
+        // reset accumulators when scroll mode is changed.
+        accum_count = 0;
+        accum_x = 0;
+        accum_y = 0;
+    }
 }
 
 #endif // TRACKBALL_DRIVER_DISABLE

--- a/qmk_firmware/keyboards/keyball/rev1/trackball.h
+++ b/qmk_firmware/keyboards/keyball/rev1/trackball.h
@@ -22,10 +22,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <stdint.h>
 
-// trackball_process_delta_user will be callbacked when trackball detects some
+// trackball_process_user will be callbacked when trackball detects some
 // rotation. User can override default behavior of trackball by defining this
 // function.
-void trackball_process_delta_user(int8_t dx, int8_t dy);
+void trackball_process_user(int8_t dx, int8_t dy);
 
 // trackball_get_scroll_mode returns current scroll ode of trackball.
 bool trackball_get_scroll_mode(void);


### PR DESCRIPTION
平均計算時等の割り算によって切り捨てられていたゆっくりとした微小な回転を拾って
ポインタ移動やスクロール量に反映できるようにしました。
結果的に秒間ミリ以下の微細な動きも反映できるようになります。

それに加えて以下の修正をしています。

* 関数名の修正 `trackball_process_user()` ← `trackball_process_delta_user()` 
    あまりに冗長だったので
* ドキュメントのファイル名を変更: `features_ja.md` ← `feature_ja.md` 
    複数のことについて書いてるのに単数形だったのは収まりが悪かったので
* secondary (slave) 側の trackball に対応するための布石を追加
* 平均計算のための累積処理にてオーバーフローを考慮
    `TRACKBALL_SAMPLE_COUNT` を大きくしてトラックボールを速く回すと、反対に動くことがあるのを防止
* スクロールモード変更時に累積をリセット