### PR TITLE
introduce OLED Kit: common library

### DIFF
--- a/qmk_firmware/keyboards/keyball/keymaps/TBscroll/config.h
+++ b/qmk_firmware/keyboards/keyball/keymaps/TBscroll/config.h
@@ -68,4 +68,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // disable Keyball's default trackball driver.
 #define TRACKBALL_DRIVER_DISABLE
 
+// disable Keyball's OLED kit
+#define OLEDKIT_DISABLE
+
 #define OLED_FONT_H "keyboards/claw44/lib/glcdfont.c"

--- a/qmk_firmware/keyboards/keyball/keymaps/default/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keymaps/default/keymap.c
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "pointing_device.h"
 #include "trackball.h"
+#include "oledkit.h"
 
 bool isScrollMode;
 
@@ -187,41 +188,27 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 
 #ifdef OLED_DRIVER_ENABLE
 
-void render_layer_state(void) {
+void oledkit_render_info_user(void) {
+    const char *n;
     switch (get_highest_layer(layer_state)) {
         case _QWERTY:
-            oled_write_ln_P(PSTR("Layer: Default"), false);
+            n = PSTR("Default");
             break;
         case _RAISE:
-            oled_write_ln_P(PSTR("Layer: Raise"), false);
+            n = PSTR("Raise");
             break;
         case _LOWER:
-            oled_write_ln_P(PSTR("Layer: Lower"), false);
+            n = PSTR("Lower");
             break;
         case _BALL:
-            oled_write_ln_P(PSTR("Layer: Adjust"), false);
+            n = PSTR("Adjust");
             break;
         default:
-            oled_write_ln_P(PSTR("Layer: Undefined"), false);
+            n = PSTR("Undefined");
+            break;
     }
-}
-
-void render_logo(void) {
-    static const char PROGMEM logo[] = {0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8a, 0x8b, 0x8c, 0x8d, 0x8e, 0x8f, 0x90, 0x91, 0x92, 0x93, 0x94, 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf, 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xcb, 0xcc, 0xcd, 0xce, 0xcf, 0xd0, 0xd1, 0xd2, 0xd3, 0xd4, 0};
-    oled_write_P(logo, false);
-}
-
-void oled_task_user(void) {
-    if (is_keyboard_master()) {
-        render_layer_state();
-    } else {
-        render_logo();
-    }
-}
-
-oled_rotation_t oled_init_user(oled_rotation_t rotation) {
-    if (!is_keyboard_master()) return OLED_ROTATION_180;
-    return rotation;
+    oled_write_P(PSTR("Layer: "), false);
+    oled_write_ln_P(n, false);
 }
 
 #endif

--- a/qmk_firmware/keyboards/keyball/keymaps/via/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keymaps/via/keymap.c
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "pointing_device.h"
 #include "trackball.h"
+#include "oledkit.h"
 
 bool isScrollMode;
 
@@ -187,41 +188,27 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 
 #ifdef OLED_DRIVER_ENABLE
 
-void render_layer_state(void) {
+void oledkit_render_info_user(void) {
+    const char *n;
     switch (get_highest_layer(layer_state)) {
         case _QWERTY:
-            oled_write_ln_P(PSTR("Layer: Default"), false);
+            n = PSTR("Default");
             break;
         case _RAISE:
-            oled_write_ln_P(PSTR("Layer: Raise"), false);
+            n = PSTR("Raise");
             break;
         case _LOWER:
-            oled_write_ln_P(PSTR("Layer: Lower"), false);
+            n = PSTR("Lower");
             break;
         case _BALL:
-            oled_write_ln_P(PSTR("Layer: Adjust"), false);
+            n = PSTR("Adjust");
             break;
         default:
-            oled_write_ln_P(PSTR("Layer: Undefined"), false);
+            n = PSTR("Undefined");
+            break;
     }
-}
-
-void render_logo(void) {
-    static const char PROGMEM logo[] = {0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8a, 0x8b, 0x8c, 0x8d, 0x8e, 0x8f, 0x90, 0x91, 0x92, 0x93, 0x94, 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf, 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xcb, 0xcc, 0xcd, 0xce, 0xcf, 0xd0, 0xd1, 0xd2, 0xd3, 0xd4, 0};
-    oled_write_P(logo, false);
-}
-
-void oled_task_user(void) {
-    if (is_keyboard_master()) {
-        render_layer_state();
-    } else {
-        render_logo();
-    }
-}
-
-oled_rotation_t oled_init_user(oled_rotation_t rotation) {
-    if (!is_keyboard_master()) return OLED_ROTATION_180;
-    return rotation;
+    oled_write_P(PSTR("Layer: "), false);
+    oled_write_ln_P(n, false);
 }
 
 #endif

--- a/qmk_firmware/keyboards/keyball/keymaps/via_Left/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keymaps/via_Left/keymap.c
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "pointing_device.h"
 #include "trackball.h"
+#include "oledkit.h"
 
 bool isScrollMode;
 
@@ -187,41 +188,27 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 
 #ifdef OLED_DRIVER_ENABLE
 
-void render_layer_state(void) {
+void oledkit_render_info_user(void) {
+    const char *n;
     switch (get_highest_layer(layer_state)) {
         case _QWERTY:
-            oled_write_ln_P(PSTR("Layer: Default"), false);
+            n = PSTR("Default");
             break;
         case _RAISE:
-            oled_write_ln_P(PSTR("Layer: Raise"), false);
+            n = PSTR("Raise");
             break;
         case _LOWER:
-            oled_write_ln_P(PSTR("Layer: Lower"), false);
+            n = PSTR("Lower");
             break;
         case _BALL:
-            oled_write_ln_P(PSTR("Layer: Adjust"), false);
+            n = PSTR("Adjust");
             break;
         default:
-            oled_write_ln_P(PSTR("Layer: Undefined"), false);
+            n = PSTR("Undefined");
+            break;
     }
-}
-
-void render_logo(void) {
-    static const char PROGMEM logo[] = {0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8a, 0x8b, 0x8c, 0x8d, 0x8e, 0x8f, 0x90, 0x91, 0x92, 0x93, 0x94, 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf, 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xcb, 0xcc, 0xcd, 0xce, 0xcf, 0xd0, 0xd1, 0xd2, 0xd3, 0xd4, 0};
-    oled_write_P(logo, false);
-}
-
-void oled_task_user(void) {
-    if (is_keyboard_master()) {
-        render_layer_state();
-    } else {
-        render_logo();
-    }
-}
-
-oled_rotation_t oled_init_user(oled_rotation_t rotation) {
-    if (!is_keyboard_master()) return OLED_ROTATION_180;
-    return rotation;
+    oled_write_P(PSTR("Layer: "), false);
+    oled_write_ln_P(n, false);
 }
 
 #endif

--- a/qmk_firmware/keyboards/keyball/rev1/features_ja.md
+++ b/qmk_firmware/keyboards/keyball/rev1/features_ja.md
@@ -1,6 +1,8 @@
 # Keyball のカスタマイズ可能な機能
 
-## トラックボール
+## トラックボールドライバ
+
+Keyballに搭載されているトラックボールのドライバーです。
 
 ### `TRACKBALL_DRIVER_DISABLE`
 
@@ -13,7 +15,7 @@ Keyballに付属のデフォルトのトラックボールドライバーを無�
 設定例:
 
 ```c
-#define TRACKBALL_DRIVER_DISABLE 100
+#define TRACKBALL_DRIVER_DISABLE
 ```
 
 ### `TRACKBALL_SAMPLE_COUNT`
@@ -69,3 +71,87 @@ void trackball_process_user(int8_t dx, int8_t dy) {
 ### `void trackball_set_scroll_mode(bool mode)` API
 
 トラックボールのスクロールモードを変更します。
+
+## OLED Kit
+
+OLED KitはKeyballのキーマップがOLEDにロゴなどの各種情報を表示するのを容易にする
+ためのライブラリです。キーマップの rules.mk に `OLED_DRIVER_ENABLE = yes` を追
+加すれば自動的に利用されますが、キーマップで表示内容をカスタマイズすることもで
+きます。
+
+表示内容をカスタマイズするには keymap.c 等に以下の2つを追加してください。
+
+1. `#include "oledkit.h"`
+2. `void oledkit_render_info_user(void)` を定義する
+
+`oledkit_render_info_user()` はプライマリ(USBケーブルが接続されている)側のキー
+ボードに情報を表示する際にコールバックされる関数です。レイヤー状態などの各種情
+報を `oled_write_*()` を用いてプライマリ側のOLEDに描画することができます。
+
+例: keymaps/default/keymap.c より抜粋
+
+```c
+#ifdef OLED_DRIVER_ENABLE
+
+void oledkit_render_info_user(void) {
+    const char *n;
+    switch (get_highest_layer(layer_state)) {
+        case _QWERTY:
+            n = PSTR("Default");
+            break;
+        case _RAISE:
+            n = PSTR("Raise");
+            break;
+        case _LOWER:
+            n = PSTR("Lower");
+            break;
+        case _BALL:
+            n = PSTR("Adjust");
+            break;
+        default:
+            n = PSTR("Undefined");
+            break;
+    }
+    oled_write_P(PSTR("Layer: "), false);
+    oled_write_ln_P(n, false);
+}
+
+#endif
+```
+
+この例は現在アクティブなレイヤー名を表示するという、OLEDの良くある利用方法で
+す。
+
+以下では OLED Kit の設定項目を解説します。
+
+### `OLEDKIT_DISABLE` define マクロ
+
+OLED Kitを無効化する設定項目です。各キーマップでOLED Kitを使いたくない場合、す
+なわちOLED表示を完全に自身でコントロールしたい場合に設定してください。
+
+各キーマップの config.h で設定できます。
+
+設定例:
+
+```c
+#define OLEDKIT_DISABLE
+```
+
+### `oledkit_render_info_user()` オーバーライド可能関数
+
+`oledkit_render_info_user()` 関数を定義するとプライマリ側のOLEDに表示する内容を
+カスタマイズできます。デフォルトではロゴを表示するようになっています。
+
+各キーマップの keymap.c で定義できます。
+
+設定例は上述してあります。
+
+### `oledkit_render_logo_user()` オーバーライド可能関数
+
+`oledkit_render_logo_user` 関数を定義するとセカンダリ(USBケーブルが接続されてい
+ない)側のOLEDに表示する内容をカスタマイズできます。デフォルトではロゴを表示する
+ようになっています。ただしキーボードとしての主要な情報はほぼプライマリ側に集約
+されているため、アクティブなレイヤーやタイプしたキーなどの情報を表示することは
+できません。
+
+各キーマップの keymap.c で定義できます。

--- a/qmk_firmware/keyboards/keyball/rev1/oledkit.c
+++ b/qmk_firmware/keyboards/keyball/rev1/oledkit.c
@@ -1,0 +1,49 @@
+/*
+Copyright 2021 @Yowkees
+Copyright 2021 MURAOKA Taro (aka KoRoN, @kaoriya)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "quantum.h"
+
+#if defined(OLED_DRIVER_ENABLE) && !defined(OLEDKIT_DISABLE)
+
+static const char PROGMEM logo[] = {
+    0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8a, 0x8b, 0x8c, 0x8d, 0x8e, 0x8f, 0x90, 0x91, 0x92, 0x93, 0x94,
+    0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf, 0xb0, 0xb1, 0xb2, 0xb3, 0xb4,
+    0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xcb, 0xcc, 0xcd, 0xce, 0xcf, 0xd0, 0xd1, 0xd2, 0xd3, 0xd4,
+    0};
+
+__attribute__((weak)) void oledkit_render_logo_user(void) {
+    oled_write_P(logo, false);
+}
+
+__attribute__((weak)) void oledkit_render_info_user(void) {
+    oled_write_P(logo, false);
+}
+
+__attribute__((weak)) void oled_task_user(void) {
+    if (is_keyboard_master()) {
+        oledkit_render_info_user();
+    } else {
+        oledkit_render_logo_user();
+    }
+}
+
+__attribute__((weak)) oled_rotation_t oled_init_user(oled_rotation_t rotation) {
+    return !is_keyboard_master() ? OLED_ROTATION_180 : rotation;
+}
+
+#endif // OLED_DRIVER_ENABLE

--- a/qmk_firmware/keyboards/keyball/rev1/oledkit.h
+++ b/qmk_firmware/keyboards/keyball/rev1/oledkit.h
@@ -1,0 +1,34 @@
+/*
+Copyright 2021 @Yowkees
+Copyright 2021 MURAOKA Taro (aka KoRoN, @kaoriya)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#if defined(OLED_DRIVER_ENABLE) && !defined(OLEDKIT_DISABLE)
+
+// oledkit_render_info_user renders keyboard's internal state information to
+// primary board. A keymap can override this by defining a function with same
+// signature.
+//
+// It render a logo as default.
+void oledkit_render_info_user(void);
+
+// oledkit_render_logo_user renders a logo of keyboard to secondary board.
+// A keymap can override this by defining a function with same signature.
+void oledkit_render_logo_user(void);
+
+#endif // OLED_DRIVER_ENABLE

--- a/qmk_firmware/keyboards/keyball/rev1/rules.mk
+++ b/qmk_firmware/keyboards/keyball/rev1/rules.mk
@@ -19,3 +19,4 @@ OLED_DRIVER_ENABLE = no     # Add OLED displays support
 SPLIT_KEYBOARD = yes
 
 SRC += trackball.c
+SRC += oledkit.c


### PR DESCRIPTION
OLEDの良くあるコードをライブラリ的にキーボード側へ切り出しました。 (fixed #20)

プライマリ側のOLEDにレイヤー情報を表示するところは、
キーマップのレイヤー定義に強く依存するためキーマップ側に残っています。

ただし表示内容を構築している箇所は文字列の共通部分をくくり出すように変更することで
約30バイトの削減に成功しています。

features_ja.md にキーマップ側での設定可能項目も書いたので
念のため確認をお願いします。