### PR TITLE
The left detector logic seems to be reverse?

### DIFF
--- a/qmk_firmware/keyboards/keyball/rev1/ball/ball.c
+++ b/qmk_firmware/keyboards/keyball/rev1/ball/ball.c
@@ -41,11 +41,11 @@ void trackball_secondary_availablity(bool available) {
     // modify matrix_mask by secondary board type (has ball or no balls)
     int base = is_keyboard_left() ? 4 : 0;
     if (available) {
-        matrix_mask[base + 2] = 0b0111111;
-        matrix_mask[base + 3] = 0b0011111;
-        keyball_adjust_trackball_handness();
-    } else {
         matrix_mask[base + 2] = 0b0011111;
         matrix_mask[base + 3] = 0b0111111;
+        keyball_adjust_trackball_handness();
+    } else {
+        matrix_mask[base + 2] = 0b0111111;
+        matrix_mask[base + 3] = 0b0011111;
     }
 }


### PR DESCRIPTION

I had issues with enabling auto left/right detector. After a lot of diagnoses, it seems to be this section of code had a reversed logic. Please double check if this is the correct assumption.

The original code has a strange effect that left bottom row, far most button does not work if TRRS cable is connected. 

After applying this change, my keyball46 with trackball on the right side is now working correctly. 