### PR TITLE
compile with QMK 0.15.13

### DIFF
--- a/.github/workflows/build-keyball46.yml
+++ b/.github/workflows/build-keyball46.yml
@@ -18,7 +18,7 @@ jobs:
         path: __qmk__
         repository: qmk/qmk_firmware
         submodules: recursive
-        ref: '0.14.32'
+        ref: '0.15.13'
 
     - name: Install a link to own source
       run: ln -s /home/runner/work/keyball/keyball/qmk_firmware/keyboards/keyball __qmk__/keyboards/keyball

--- a/qmk_firmware/keyboards/keyball/keymaps/default/config.h
+++ b/qmk_firmware/keyboards/keyball/keymaps/default/config.h
@@ -39,7 +39,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#    define RGBLIGHT_EFFECT_CHRISTMAS
 //#    define RGBLIGHT_EFFECT_STATIC_GRADIENT
 //#    define RGBLIGHT_EFFECT_RGB_TEST
-#    define RGBLIGHT_EFFECT_ALTERNATING
+//#    define RGBLIGHT_EFFECT_ALTERNATING
 //#    define RGBLIGHT_EFFECT_TWINKLE
 #endif
 

--- a/qmk_firmware/keyboards/keyball/rev1/oledkit.c
+++ b/qmk_firmware/keyboards/keyball/rev1/oledkit.c
@@ -32,12 +32,13 @@ __attribute__((weak)) void oledkit_render_logo_user(void) { oled_write_P(logo, f
 
 __attribute__((weak)) void oledkit_render_info_user(void) { oled_write_P(logo, false); }
 
-__attribute__((weak)) void oled_task_user(void) {
+__attribute__((weak)) bool oled_task_user(void) {
     if (is_keyboard_master()) {
         oledkit_render_info_user();
     } else {
         oledkit_render_logo_user();
     }
+    return true;
 }
 
 __attribute__((weak)) oled_rotation_t oled_init_user(oled_rotation_t rotation) { return !is_keyboard_master() ? OLED_ROTATION_180 : rotation; }


### PR DESCRIPTION
QMKの最新である 0.15.x でビルドできるようにしました。
実際にビルドに使ってる QMK は 0.15.13 です。

QMKのバージョンアップに伴いdefaultのサイズが大きくなってしまい、
一部のLEDアニメーションパターンを諦め削除しました。

その他の変更点はありません。