### PR TITLE
Imporeve GitHub Actions

### DIFF
--- a/.github/actions/setup-qmk/action.yml
+++ b/.github/actions/setup-qmk/action.yml
@@ -1,0 +1,34 @@
+name: 'Setup QMK firmware'
+
+inputs:
+  version:
+    default: '0.15.13'
+    type: string
+    required: false
+  path:
+    default: '__qmk__'
+    type: string
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+  - name: Checkout qmk_firmware
+    uses: actions/checkout@v2
+    with:
+      path: ${{ inputs.path }}
+      repository: qmk/qmk_firmware
+      submodules: recursive
+      ref: ${{ inputs.version }}
+
+  - name: Install git and pip
+    shell: bash
+    run: sudo apt-get install -y git python3-pip
+
+  - name: Install QMK CLI
+    shell: bash
+    run: python3 -m pip install --user qmk
+
+  - name: Setup QMK
+    shell: bash
+    run: qmk setup --home ${{ inputs.path }} --yes

--- a/.github/workflows/build-keyball46.yml
+++ b/.github/workflows/build-keyball46.yml
@@ -1,10 +1,16 @@
 name: Build Keyball46
 
-on: push
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - 'keyball46/v[0-9]+.[0-9]+.[0-9]+*'
+  pull_request:
 
 jobs:
 
-  build-keyball46-firmwares:
+  build:
     name: Build Keyball46 firmwares
     runs-on: ubuntu-latest
 
@@ -40,3 +46,27 @@ jobs:
       with:
         name: keyball46-firmwares
         path: __qmk__/*.hex
+
+  release:
+    name: Release Keyball46 firmwares
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'keyball46/v')
+
+    steps:
+    - name: Download built firmwares
+      uses: actions/download-artifact@v2
+      with:
+        name: keyball46-firmwares
+    - name: List assets
+      run: ls -l *.hex
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        draft: true
+        prerelease: ${{ contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') }}
+        files: |
+          *.hex
+        fail_on_unmatched_files: true
+        generate_release_notes: true
+        append_body: true

--- a/.github/workflows/build-keyball46.yml
+++ b/.github/workflows/build-keyball46.yml
@@ -12,25 +12,11 @@ jobs:
     - name: Checkout source
       uses: actions/checkout@v2
 
-    - name: Checkout qmk_firmware
-      uses: actions/checkout@v2
-      with:
-        path: __qmk__
-        repository: qmk/qmk_firmware
-        submodules: recursive
-        ref: '0.15.13'
+    - name: Setup QMK firmware
+      uses: ./.github/actions/setup-qmk
 
     - name: Install a link to own source
       run: ln -s /home/runner/work/keyball/keyball/qmk_firmware/keyboards/keyball __qmk__/keyboards/keyball
-
-    - name: Install git and pip
-      run: sudo apt-get install -y git python3-pip
-
-    - name: Install QMK CLI
-      run: python3 -m pip install --user qmk
-
-    - name: Setup QMK
-      run: qmk setup --home __qmk__ --yes
 
     - run: qmk compile -j 4 -kb keyball/keyball46 -km default
       continue-on-error: true

--- a/.github/workflows/build-keyball46.yml
+++ b/.github/workflows/build-keyball46.yml
@@ -16,7 +16,7 @@ jobs:
       uses: ./.github/actions/setup-qmk
 
     - name: Install a link to own source
-      run: ln -s /home/runner/work/keyball/keyball/qmk_firmware/keyboards/keyball __qmk__/keyboards/keyball
+      run: ln -s $(pwd)/qmk_firmware/keyboards/keyball __qmk__/keyboards/keyball
 
     - run: qmk compile -j 4 -kb keyball/keyball46 -km default
       continue-on-error: true

--- a/.github/workflows/build-keyball61.yml
+++ b/.github/workflows/build-keyball61.yml
@@ -12,25 +12,11 @@ jobs:
     - name: Checkout source
       uses: actions/checkout@v2
 
-    - name: Checkout qmk_firmware
-      uses: actions/checkout@v2
-      with:
-        path: __qmk__
-        repository: qmk/qmk_firmware
-        submodules: recursive
-        ref: '0.15.13'
+    - name: Setup QMK firmware
+      uses: ./.github/actions/setup-qmk
 
     - name: Install a link to own source
       run: ln -s /home/runner/work/keyball/keyball/qmk_firmware/keyboards/keyball __qmk__/keyboards/keyball
-
-    - name: Install git and pip
-      run: sudo apt-get install -y git python3-pip
-
-    - name: Install QMK CLI
-      run: python3 -m pip install --user qmk
-
-    - name: Setup QMK
-      run: qmk setup --home __qmk__ --yes
 
     - run: qmk compile -j 4 -kb keyball/keyball61 -km default
       continue-on-error: true

--- a/.github/workflows/build-keyball61.yml
+++ b/.github/workflows/build-keyball61.yml
@@ -1,10 +1,16 @@
 name: Build Keyball61
 
-on: push
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - 'keyball61/v[0-9]+.[0-9]+.[0-9]+*'
+  pull_request:
 
 jobs:
 
-  build-keyball61-firmwares:
+  build:
     name: Build Keyball61 firmwares
     runs-on: ubuntu-latest
 
@@ -32,3 +38,27 @@ jobs:
       with:
         name: keyball61-firmwares
         path: __qmk__/*.hex
+
+  release:
+    name: Release Keyball61 firmwares
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'keyball61/v')
+
+    steps:
+    - name: Download built firmwares
+      uses: actions/download-artifact@v2
+      with:
+        name: keyball61-firmwares
+    - name: List assets
+      run: ls -l *.hex
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        draft: true
+        prerelease: ${{ contains(github.ref_name, '-alpha.') || contains(github.ref_name, '-beta.') }}
+        files: |
+          *.hex
+        fail_on_unmatched_files: true
+        generate_release_notes: true
+        append_body: true

--- a/.github/workflows/build-keyball61.yml
+++ b/.github/workflows/build-keyball61.yml
@@ -16,7 +16,7 @@ jobs:
       uses: ./.github/actions/setup-qmk
 
     - name: Install a link to own source
-      run: ln -s /home/runner/work/keyball/keyball/qmk_firmware/keyboards/keyball __qmk__/keyboards/keyball
+      run: ln -s $(pwd)/qmk_firmware/keyboards/keyball __qmk__/keyboards/keyball
 
     - run: qmk compile -j 4 -kb keyball/keyball61 -km default
       continue-on-error: true


### PR DESCRIPTION
* use common action to setup QMK
* create release by tag
   * `keyball46/v{X}.{Y}.{Z}` for Keyball46
   * `keyball61/v{X}.{Y}.{Z}` for Keyball61

特定のパターンにマッチするtagを作ると
自動でビルドが走ってリリースを作りファームをassetsとして追加してくれます。
draft状態にしてますがリリース作業が楽になることを期待しています。