### PR TITLE
keyball61: sync scroll mode with layer state 3

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball61/keyball61.c
+++ b/qmk_firmware/keyboards/keyball/keyball61/keyball61.c
@@ -340,6 +340,12 @@ static void keyball_set_cpi_invoke(void) {
 
 //////////////////////////////////////////////////////////////////////////////
 
+bool keyball_get_scroll_mode(void) { return scroll_mode; }
+
+void keyball_set_scroll_mode(bool mode) {
+    scroll_mode = mode;
+}
+
 #ifdef OLED_ENABLE
 
 static const char *format_4d(int8_t d) {

--- a/qmk_firmware/keyboards/keyball/keyball61/keyball61.h
+++ b/qmk_firmware/keyboards/keyball/keyball61/keyball61.h
@@ -129,6 +129,13 @@ enum keyball_keycodes {
 //////////////////////////////////////////////////////////////////////////////
 // Experimental API
 
+// keyball_get_scroll_mode returns current scroll ode of trackball.
+bool keyball_get_scroll_mode(void);
+
+// keyball_set_scroll_mode enables/disables scroll mode of trackball.
+// When scroll mode enabled, rotating trackball reports scrolling events.
+void keyball_set_scroll_mode(bool mode);
+
 // keyball_oled_render_ballinfo renders ball information to OLED.
 // It uses just 21 columns to show the info.
 void keyball_oled_render_ballinfo(void);

--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/default/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/default/keymap.c
@@ -56,6 +56,12 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 // clang-format on
 
+layer_state_t layer_state_set_user(layer_state_t state) {
+    // Auto enable scroll mode when the highest layer is 3
+    keyball_set_scroll_mode(get_highest_layer(state) == 3);
+    return state;
+}
+
 #ifdef OLED_ENABLE
 
 #include "lib/oledkit/oledkit.h"

--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/via/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/via/keymap.c
@@ -56,6 +56,12 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 // clang-format on
 
+layer_state_t layer_state_set_user(layer_state_t state) {
+    // Auto enable scroll mode when the highest layer is 3
+    keyball_set_scroll_mode(get_highest_layer(state) == 3);
+    return state;
+}
+
 #ifdef OLED_ENABLE
 
 #include "lib/oledkit/oledkit.h"


### PR DESCRIPTION
fix https://github.com/Yowkees/keyball/issues/85

Auto enable scroll mode when layer state 3 is enabled.
Only for `via` keymap.