### PR TITLE
suppress ball a while, when scroll mode changed

### DIFF
--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
@@ -32,6 +32,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define KEYBALL_REPORTMOUSE_INTERVAL 8  // mouse report rate: 125Hz
 #endif
 
+#ifndef KEYBALL_SCROLLBALL_INHIVITOR
+#    define KEYBALL_SCROLLBALL_INHIVITOR 50
+#endif
+
 //////////////////////////////////////////////////////////////////////////////
 // Constants
 
@@ -103,8 +107,9 @@ typedef struct {
     uint8_t cpi_value;
     bool    cpi_changed;
 
-    bool    scroll_mode;
-    uint8_t scroll_div;
+    bool     scroll_mode;
+    uint8_t  scroll_div;
+    uint32_t scroll_changed;
 
     uint16_t       last_kc;
     keypos_t       last_pos;


### PR DESCRIPTION
scrollモードを切り替えた直後に、極短い期間トラックボールの動きを無視する機能を追加しました。

config.h に `KEYBALL_SCROLLBALL_INHIVITOR` で期間をミリ秒単位で設定できます。
デフォルトでは `50` ミリ秒に設定してあります。
無効化するには 0 を設定します。

```c
#define KEYBALL_SCROLLBALL_INHIVITOR 0
```


参考:

> keyball46スクロール後にレイヤーが0に戻った瞬間マウスポインター少し移動するのどうにかなりませんか

https://twitter.com/kaspinMTH/status/1490152961640923139

---

(In English)

I added a feature to suppress to sense trackball, just after changed scroll mode.

You can configure that inhibition period by `KEYBALL_SCROLLBALL_INHIVITOR` in config.h
Its unit is millisecond and default is `50`.
To disable this feature set `0`

```c
#define KEYBALL_SCROLLBALL_INHIVITOR 0
```
