### PR TITLE
keyball46: earlier ball detection

### DIFF
--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
@@ -107,8 +107,17 @@ static void add_scroll_div(int8_t delta) {
 //////////////////////////////////////////////////////////////////////////////
 // Pointing device driver
 
-void pointing_device_driver_init(void) {
+#if KEYBALL_MODEL == 46
+void keyboard_pre_init_kb(void) {
     keyball.this_have_ball = pmw3360_init();
+    keyboard_pre_init_user();
+}
+#endif
+
+void pointing_device_driver_init(void) {
+#if KEYBALL_MODEL != 46
+    keyball.this_have_ball = pmw3360_init();
+#endif
     if (keyball.this_have_ball) {
         pmw3360_cpi_set(CPI_DEFAULT - 1);
         pmw3360_reg_write(pmw3360_Motion_Burst, 0);


### PR DESCRIPTION
Keyball46においてボール有無の検出タイミングを早めました。

Keyball46は他のKeyballと異なり、左右検出の方法がボールの有無に依存します。
しかしボールの有無の検出は `pointing_device_driver_init` で行っているのに対し
初回の左右チェックは `matrix_init` で行っており
これは `pointing_device_driver_init` よりも先行します。
またこの初回の結果はメモリ上にキャッシュされいくつかのシーンで使用されます。

これによりキャッシュされた左右情報と、ボールの有無の検出後の左右情報に矛盾が生じ
意図しない動作を引き起こしてました。
具体的には左手ボールで左にUSBを接続したときに顕在化してました。
(ほかにも幾つかのケースで顕在化していたと考えられます)

本修正ではKeyball46のみボールの有無検出を `keyboard_pre_init_kb` にまで早めました。
これにより初回の左右チェック前にボール有無情報がセットされ、元々の意図通りに動作します。

変更を46にのみ限定したのは、この修正に伴い39や61のテストをやり直さなければならないのを嫌ったためです。
将来的にはコードを統一してメンテコストを下げる意味で、39や61のコードも共通化しても良いかもしれません。