### PR TITLE
scroll snap feature

### DIFF
--- a/qmk_firmware/keyboards/keyball/drivers/pmw3360/pmw3360.c
+++ b/qmk_firmware/keyboards/keyball/drivers/pmw3360/pmw3360.c
@@ -22,7 +22,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define PMW3360_SPI_DIVISOR (F_CPU / PMW3360_CLOCKS)
 #define PMW3360_CLOCKS 70000000
 
-bool pmw3360_spi_start(void) { return spi_start(PMW3360_NCS_PIN, false, PMW3360_SPI_MODE, PMW3360_SPI_DIVISOR); }
+bool pmw3360_spi_start(void) {
+    return spi_start(PMW3360_NCS_PIN, false, PMW3360_SPI_MODE, PMW3360_SPI_DIVISOR);
+}
 
 uint8_t pmw3360_reg_read(uint8_t addr) {
     pmw3360_spi_start();
@@ -42,7 +44,9 @@ void pmw3360_reg_write(uint8_t addr, uint8_t data) {
     wait_us(180);
 }
 
-uint8_t pmw3360_cpi_get(void) { return pmw3360_reg_read(pmw3360_Config1); }
+uint8_t pmw3360_cpi_get(void) {
+    return pmw3360_reg_read(pmw3360_Config1);
+}
 
 void pmw3360_cpi_set(uint8_t cpi) {
     if (cpi > pmw3360_MAXCPI) {
@@ -68,7 +72,9 @@ void pmw3360_scan_perf_task(void) {
     }
 }
 
-uint32_t pmw3360_scan_rate_get(void) { return pmw3360_last_count; }
+uint32_t pmw3360_scan_rate_get(void) {
+    return pmw3360_last_count;
+}
 
 bool pmw3360_motion_read(pmw3360_motion_t *d) {
 #ifdef DEBUG_PMW3360_SCAN_RATE
@@ -97,7 +103,7 @@ bool pmw3360_motion_burst(pmw3360_motion_t *d) {
         spi_stop();
         return false;
     }
-    spi_read();  // skip Observation
+    spi_read(); // skip Observation
     d->x = spi_read();
     d->x |= spi_read() << 8;
     d->y = spi_read();

--- a/qmk_firmware/keyboards/keyball/drivers/pmw3360/pmw3360.h
+++ b/qmk_firmware/keyboards/keyball/drivers/pmw3360/pmw3360.h
@@ -127,7 +127,7 @@ typedef enum {
 } pmw3360_reg_t;
 
 enum {
-    pmw3360_MAXCPI = 0x77,  // = 119: 12000 CPI
+    pmw3360_MAXCPI = 0x77, // = 119: 12000 CPI
 };
 
 //////////////////////////////////////////////////////////////////////////////
@@ -135,8 +135,14 @@ enum {
 
 bool pmw3360_spi_start(void);
 
-void inline pmw3360_spi_stop(void) { spi_stop(); }
+void inline pmw3360_spi_stop(void) {
+    spi_stop();
+}
 
-spi_status_t inline pmw3360_spi_write(uint8_t data) { return spi_write(data); }
+spi_status_t inline pmw3360_spi_write(uint8_t data) {
+    return spi_write(data);
+}
 
-spi_status_t inline pmw3360_spi_read(void) { return spi_read(); }
+spi_status_t inline pmw3360_spi_read(void) {
+    return spi_read();
+}

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/default/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/default/keymap.c
@@ -61,7 +61,7 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 
 #ifdef OLED_ENABLE
 
-#include "lib/oledkit/oledkit.h"
+#    include "lib/oledkit/oledkit.h"
 
 void oledkit_render_info_user(void) {
     keyball_oled_render_keyinfo();

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/develop/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/develop/keymap.c
@@ -41,7 +41,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 #ifdef OLED_ENABLE
 
-#include "lib/oledkit/oledkit.h"
+#    include "lib/oledkit/oledkit.h"
 
 void oledkit_render_info_user(void) {
     keyball_oled_render_keyinfo();

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/keymap.c
@@ -61,7 +61,7 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 
 #ifdef OLED_ENABLE
 
-#include "lib/oledkit/oledkit.h"
+#    include "lib/oledkit/oledkit.h"
 
 void oledkit_render_info_user(void) {
     keyball_oled_render_keyinfo();

--- a/qmk_firmware/keyboards/keyball/keyball46/keyball46.c
+++ b/qmk_firmware/keyboards/keyball/keyball46/keyball46.c
@@ -51,7 +51,7 @@ static uint8_t peek_matrix_intersection(pin_t out_pin, pin_t in_pin) {
 }
 
 bool is_keyboard_left(void) {
-    return !peek_matrix_intersection(keyball.this_have_ball ? F7: F6, B5);
+    return !peek_matrix_intersection(keyball.this_have_ball ? F7 : F6, B5);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -59,7 +59,7 @@ bool is_keyboard_left(void) {
 void keyball_on_adjust_layout(keyball_adjust_t v) {
     if (v == KEYBALL_ADJUST_PRIMARY) {
         // adjust matrix mask
-        bool is_left = is_keyboard_left();
+        bool is_left                                                      = is_keyboard_left();
         matrix_mask[(is_left ? 2 : 6) + (keyball.this_have_ball ? 0 : 1)] = 0b0111111;
         matrix_mask[(is_left ? 6 : 2) + (keyball.that_have_ball ? 0 : 1)] = 0b0111111;
     }

--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/develop/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/develop/keymap.c
@@ -49,7 +49,7 @@ void keyboard_post_init_user(void) {
 
 #ifdef OLED_ENABLE
 
-#include "lib/oledkit/oledkit.h"
+#    include "lib/oledkit/oledkit.h"
 
 void oledkit_render_info_user(void) {
     keyball_oled_render_keyinfo();

--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/via/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/via/keymap.c
@@ -64,7 +64,7 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 
 #ifdef OLED_ENABLE
 
-#include "lib/oledkit/oledkit.h"
+#    include "lib/oledkit/oledkit.h"
 
 void oledkit_render_info_user(void) {
     keyball_oled_render_keyinfo();

--- a/qmk_firmware/keyboards/keyball/keyball61/matrix.c
+++ b/qmk_firmware/keyboards/keyball/keyball61/matrix.c
@@ -22,11 +22,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "split_common/split_util.h"
 #include "split_common/transactions.h"
 
-#define PINNUM_ROW  (MATRIX_ROWS / 2)
-#define PINNUM_COL  (MATRIX_COLS / 2)
+#define PINNUM_ROW (MATRIX_ROWS / 2)
+#define PINNUM_COL (MATRIX_COLS / 2)
 
-#define ROWS_PER_HAND           (MATRIX_ROWS / 2)
-#define MATRIXSIZE_PER_HAND     (ROWS_PER_HAND * sizeof(matrix_row_t))
+#define ROWS_PER_HAND (MATRIX_ROWS / 2)
+#define MATRIXSIZE_PER_HAND (ROWS_PER_HAND * sizeof(matrix_row_t))
 
 static pin_t row_pins[PINNUM_ROW] = MATRIX_ROW_PINS;
 static pin_t col_pins[PINNUM_COL] = MATRIX_COL_PINS;
@@ -61,7 +61,7 @@ static bool duplex_scan(matrix_row_t current_matrix[]) {
         for (uint8_t col = 0; col < PINNUM_COL; col++) {
             bool on = !get_pin(col_pins[col]);
             if (on) {
-                next |= 1 << col; 
+                next |= 1 << col;
             } else {
                 next &= ~(1 << col);
             }
@@ -70,7 +70,7 @@ static bool duplex_scan(matrix_row_t current_matrix[]) {
         matrix_output_unselect_delay(row, next != 0);
         if (current_matrix[row] != next) {
             current_matrix[row] = next;
-            changed = true;
+            changed             = true;
         }
     }
 
@@ -81,7 +81,7 @@ static bool duplex_scan(matrix_row_t current_matrix[]) {
         matrix_output_select_delay();
         matrix_row_t shifter = ((matrix_row_t)1) << (col + PINNUM_COL);
         for (uint8_t row = 0; row < PINNUM_ROW; row++) {
-            bool on = !get_pin(row_pins[row]);
+            bool         on   = !get_pin(row_pins[row]);
             matrix_row_t prev = current_matrix[row];
             if (on) {
                 current_matrix[row] |= shifter;
@@ -115,7 +115,9 @@ void matrix_init_custom(void) {
 }
 
 // user-defined overridable functions
-__attribute__((weak)) void matrix_slave_scan_kb(void) { matrix_slave_scan_user(); }
+__attribute__((weak)) void matrix_slave_scan_kb(void) {
+    matrix_slave_scan_user();
+}
 __attribute__((weak)) void matrix_slave_scan_user(void) {}
 
 // override quantum/matrix_common.c
@@ -135,8 +137,8 @@ uint8_t matrix_scan(void) {
     }
 
     // receive from secondary.
-    static bool last_connected = false;
-    matrix_row_t *that_raw = raw_matrix + ROWS_PER_HAND;
+    static bool   last_connected = false;
+    matrix_row_t* that_raw       = raw_matrix + ROWS_PER_HAND;
     memset(that_raw, 0, MATRIXSIZE_PER_HAND);
     if (transport_master_if_connected(matrix + thisHand, that_raw)) {
         last_connected = true;

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
@@ -25,15 +25,27 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 
 #ifndef KEYBALL_SCROLL_DIV_DEFAULT
-#    define KEYBALL_SCROLL_DIV_DEFAULT 4  // 4: 1/8 (1/2^(n-1))
+#    define KEYBALL_SCROLL_DIV_DEFAULT 4 // 4: 1/8 (1/2^(n-1))
 #endif
 
 #ifndef KEYBALL_REPORTMOUSE_INTERVAL
-#    define KEYBALL_REPORTMOUSE_INTERVAL 8  // mouse report rate: 125Hz
+#    define KEYBALL_REPORTMOUSE_INTERVAL 8 // mouse report rate: 125Hz
 #endif
 
 #ifndef KEYBALL_SCROLLBALL_INHIVITOR
 #    define KEYBALL_SCROLLBALL_INHIVITOR 50
+#endif
+
+#ifndef KEYBALL_SCROLLSNAP_ENABLE
+#    define KEYBALL_SCROLLSNAP_ENABLE 1
+#endif
+
+#ifndef KEYBALL_SCROLLSNAP_RESET_TIMER
+#    define KEYBALL_SCROLLSNAP_RESET_TIMER 100
+#endif
+
+#ifndef KEYBALL_SCROLLSNAP_TENSION_THRESHOLD
+#    define KEYBALL_SCROLLSNAP_TENSION_THRESHOLD 8
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
@@ -55,20 +67,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // Types
 
 enum keyball_keycodes {
-    KBC_RST = SAFE_RANGE,  // Keyball configuration: reset to default
-    KBC_SAVE,              // Keyball configuration: save to EEPROM
+    KBC_RST = SAFE_RANGE, // Keyball configuration: reset to default
+    KBC_SAVE,             // Keyball configuration: save to EEPROM
 
-    CPI_I100,  // CPI +100 CPI
-    CPI_D100,  // CPI -100 CPI
-    CPI_I1K,   // CPI +1000 CPI
-    CPI_D1K,   // CPI -1000 CPI
+    CPI_I100, // CPI +100 CPI
+    CPI_D100, // CPI -100 CPI
+    CPI_I1K,  // CPI +1000 CPI
+    CPI_D1K,  // CPI -1000 CPI
 
     // In scroll mode, motion from primary trackball is treated as scroll
     // wheel.
-    SCRL_TO,   // Toggle scroll mode
-    SCRL_MO,   // Momentary scroll mode
-    SCRL_DVI,  // Increment scroll divider
-    SCRL_DVD,  // Decrement scroll divider
+    SCRL_TO,  // Toggle scroll mode
+    SCRL_MO,  // Momentary scroll mode
+    SCRL_DVI, // Increment scroll divider
+    SCRL_DVD, // Decrement scroll divider
 
     KEYBALL_SAFE_RANGE,
 };
@@ -77,12 +89,12 @@ typedef union {
     uint32_t raw;
     struct {
         uint8_t cpi : 7;
-        uint8_t sdiv : 3;  // scroll divider
+        uint8_t sdiv : 3; // scroll divider
     };
 } keyball_config_t;
 
 typedef struct {
-    uint8_t ballcnt;  // count of balls: support only 0 or 1, for now
+    uint8_t ballcnt; // count of balls: support only 0 or 1, for now
 } keyball_info_t;
 
 typedef struct {
@@ -104,8 +116,11 @@ typedef struct {
     bool    cpi_changed;
 
     bool     scroll_mode;
+    uint32_t scroll_mode_changed;
     uint8_t  scroll_div;
-    uint32_t scroll_changed;
+
+    uint32_t         scroll_snap_last;
+    keyball_motion_t scroll_snap_tension;
 
     uint16_t       last_kc;
     keypos_t       last_pos;

--- a/qmk_firmware/keyboards/keyball/lib/oledkit/oledkit.c
+++ b/qmk_firmware/keyboards/keyball/lib/oledkit/oledkit.c
@@ -28,9 +28,13 @@ static const char PROGMEM logo[] = {
     0};
 // clang-format on
 
-__attribute__((weak)) void oledkit_render_logo_user(void) { oled_write_P(logo, false); }
+__attribute__((weak)) void oledkit_render_logo_user(void) {
+    oled_write_P(logo, false);
+}
 
-__attribute__((weak)) void oledkit_render_info_user(void) { oled_write_P(logo, false); }
+__attribute__((weak)) void oledkit_render_info_user(void) {
+    oled_write_P(logo, false);
+}
 
 __attribute__((weak)) bool oled_task_user(void) {
     if (is_keyboard_master()) {
@@ -41,6 +45,8 @@ __attribute__((weak)) bool oled_task_user(void) {
     return true;
 }
 
-__attribute__((weak)) oled_rotation_t oled_init_user(oled_rotation_t rotation) { return !is_keyboard_master() ? OLED_ROTATION_180 : rotation; }
+__attribute__((weak)) oled_rotation_t oled_init_user(oled_rotation_t rotation) {
+    return !is_keyboard_master() ? OLED_ROTATION_180 : rotation;
+}
 
-#endif  // OLED_ENABLE
+#endif // OLED_ENABLE

--- a/qmk_firmware/keyboards/keyball/lib/oledkit/oledkit.h
+++ b/qmk_firmware/keyboards/keyball/lib/oledkit/oledkit.h
@@ -31,4 +31,4 @@ void oledkit_render_info_user(void);
 // A keymap can override this by defining a function with same signature.
 void oledkit_render_logo_user(void);
 
-#endif  // OLED_ENABLE
+#endif // OLED_ENABLE


### PR DESCRIPTION
introduce scroll snap feature. scroll snap locks an axis to scroll at
first, then unlock it if ball moved to another axis an amount.

apply clang-format. configuration for clang-format is changed in QMK.
this apply it on files exclude config.h files.

invert horizontal scroll. it was just a bug.

----

(in Japanese/日本語)

scroll snap機能を追加しました。scroll snapは、スクロールモードにおいて最初はスクロール方向を片方の軸に固定しておき、もう一方の軸にある程度にボールを転がした際にその固定を解除≒自由にスクロールできるようにする機能です。

またclang-formatを再適用しました。QMK 0.16.x においてclang-formatのコンフィギュレーションが変更になったため、それに追従する目的です。

水平方向のスクロールを逆にしました。バグ修正です。