### PR TITLE
snap vertical axis as default

### DIFF
--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
@@ -45,7 +45,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 
 #ifndef KEYBALL_SCROLLSNAP_TENSION_THRESHOLD
-#    define KEYBALL_SCROLLSNAP_TENSION_THRESHOLD 8
+#    define KEYBALL_SCROLLSNAP_TENSION_THRESHOLD 12
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
@@ -119,8 +119,8 @@ typedef struct {
     uint32_t scroll_mode_changed;
     uint8_t  scroll_div;
 
-    uint32_t         scroll_snap_last;
-    keyball_motion_t scroll_snap_tension;
+    uint32_t scroll_snap_last;
+    int8_t   scroll_snap_tension_h;
 
     uint16_t       last_kc;
     keypos_t       last_pos;


### PR DESCRIPTION
previously, snap direction is determined by first rotate direction.
it caused ignoring of begining of the scroll.

after this change, keyball assue snapping vertical axis.
begining of the scroll is treated as vertical scroll.

---

水平方向のスクロールはめったに使わないだろうということで、
デフォルトで垂直方向にスナップするようにした。

以前はスナップ方向を確定するために、
ボールの回転始まりを判定に使い読み捨てており
それが使用感を阻害していた。

同時にKeyball46で使う場合を想定したコードに修正
(ボールのx, yではなくマウスホイールのh, vで見るようにした)