### PR TITLE
use correct clock to communicate with PMW3360 sensor

### DIFF
--- a/qmk_firmware/keyboards/keyball/drivers/pmw3360/pmw3360.c
+++ b/qmk_firmware/keyboards/keyball/drivers/pmw3360/pmw3360.c
@@ -20,7 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define PMW3360_SPI_MODE 3
 #define PMW3360_SPI_DIVISOR (F_CPU / PMW3360_CLOCKS)
-#define PMW3360_CLOCKS 70000000
+#define PMW3360_CLOCKS 2000000
 
 bool pmw3360_spi_start(void) {
     return spi_start(PMW3360_NCS_PIN, false, PMW3360_SPI_MODE, PMW3360_SPI_DIVISOR);


### PR DESCRIPTION
It is too fast to communicate with PMW3360DM sensor, 70MHz.
(It is PMW3360DM internal clock, is not for SPI)

PMW3360DM's datasheet recommends 2MHz for SPI.
> ![image](https://user-images.githubusercontent.com/468368/162713689-2f8b09bc-6829-4866-b130-4a25cfb2d34b.png)

QMK treats 70MHz as zero divisor and ATmega32U4 works with 4MHz.
It works but twice of the recommended speed.

This PR fix it, to use 2MHz clock to communicate with PMW3360DM.