### PR TITLE
keyball61: extend delay after unselect pin

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball61/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball61/config.h
@@ -34,6 +34,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_COL_PINS     { F4, F5, F6, F7 }
 #define MATRIX_MASKED
 #define DEBOUNCE            5
+#define MATRIX_IO_DELAY     70
 
 // Split parameters
 #define SOFT_SERIAL_PIN         D2

--- a/qmk_firmware/keyboards/keyball/keyball61/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball61/config.h
@@ -34,7 +34,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define MATRIX_COL_PINS     { F4, F5, F6, F7 }
 #define MATRIX_MASKED
 #define DEBOUNCE            5
-#define MATRIX_IO_DELAY     70
+#define MATRIX_IO_DELAY     95
 
 // Split parameters
 #define SOFT_SERIAL_PIN         D2


### PR DESCRIPTION
to stabilize duplex matrix.

This may mitigate https://github.com/Yowkees/keyball/issues/112