### PR TITLE
define TAP_CODE_DELAY for common keymaps

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/default/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/default/config.h
@@ -32,3 +32,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define RGBLIGHT_EFFECT_ALTERNATING
 #    define RGBLIGHT_EFFECT_TWINKLE
 #endif
+
+#define TAP_CODE_DELAY 5

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/config.h
@@ -32,3 +32,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#    define RGBLIGHT_EFFECT_ALTERNATING
 //#    define RGBLIGHT_EFFECT_TWINKLE
 #endif
+
+#define TAP_CODE_DELAY 5

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/default/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/default/config.h
@@ -32,3 +32,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define RGBLIGHT_EFFECT_ALTERNATING
 #    define RGBLIGHT_EFFECT_TWINKLE
 #endif
+
+#define TAP_CODE_DELAY 5

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/via/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/via/config.h
@@ -32,3 +32,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#    define RGBLIGHT_EFFECT_ALTERNATING
 //#    define RGBLIGHT_EFFECT_TWINKLE
 #endif
+
+#define TAP_CODE_DELAY 5

--- a/qmk_firmware/keyboards/keyball/keyball46/keymaps/default/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball46/keymaps/default/config.h
@@ -35,3 +35,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #undef PRODUCT_ID
 #define PRODUCT_ID 0x0005
+
+#define TAP_CODE_DELAY 5

--- a/qmk_firmware/keyboards/keyball/keyball46/keymaps/via/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball46/keymaps/via/config.h
@@ -32,3 +32,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#    define RGBLIGHT_EFFECT_ALTERNATING
 //#    define RGBLIGHT_EFFECT_TWINKLE
 #endif
+
+#define TAP_CODE_DELAY 5

--- a/qmk_firmware/keyboards/keyball/keyball46/keymaps/via_Both/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball46/keymaps/via_Both/config.h
@@ -35,3 +35,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #undef PRODUCT_ID
 #define PRODUCT_ID 0x0003
+
+#define TAP_CODE_DELAY 5

--- a/qmk_firmware/keyboards/keyball/keyball46/keymaps/via_Left/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball46/keymaps/via_Left/config.h
@@ -35,3 +35,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #undef PRODUCT_ID
 #define PRODUCT_ID 0x0002
+
+#define TAP_CODE_DELAY 5

--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/default/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/default/config.h
@@ -32,3 +32,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define RGBLIGHT_EFFECT_ALTERNATING
 #    define RGBLIGHT_EFFECT_TWINKLE
 #endif
+
+#define TAP_CODE_DELAY 5

--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/via/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/via/config.h
@@ -32,3 +32,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#    define RGBLIGHT_EFFECT_ALTERNATING
 //#    define RGBLIGHT_EFFECT_TWINKLE
 #endif
+
+#define TAP_CODE_DELAY 5

--- a/qmk_firmware/keyboards/keyball/one47/keymaps/default/config.h
+++ b/qmk_firmware/keyboards/keyball/one47/keymaps/default/config.h
@@ -32,3 +32,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define RGBLIGHT_EFFECT_ALTERNATING
 #    define RGBLIGHT_EFFECT_TWINKLE
 #endif
+
+#define TAP_CODE_DELAY 5

--- a/qmk_firmware/keyboards/keyball/one47/keymaps/via/config.h
+++ b/qmk_firmware/keyboards/keyball/one47/keymaps/via/config.h
@@ -32,3 +32,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define RGBLIGHT_EFFECT_ALTERNATING
 #    define RGBLIGHT_EFFECT_TWINKLE
 #endif
+
+#define TAP_CODE_DELAY 5


### PR DESCRIPTION
fix https://github.com/Yowkees/keyball/issues/110

viaとdefaultのkeymapに `TAP_CODE_DELAY` を5ミリ秒にするよう設定した。

キーボードのconfig.hで設定してしまうと、
ユーザーが自前のキーマップでビルドする際に混乱する
(場合によってはビルドが失敗するようになる)
ので、デフォルトのファームウェアであるviaとdefaultだけで設定するようにした。

5ミリ秒である理由は特にないが 
`TAP_CODE_DELAY` は1以上であればコード的に有効になること
また100ミリ秒や10ミリ秒では長すぎ
1ミリ秒では短すぎると感じて5ミリ秒とした。