### PR TITLE
Switch to QMK firmware 0.19.x or above

### DIFF
--- a/.github/actions/setup-qmk/action.yml
+++ b/.github/actions/setup-qmk/action.yml
@@ -2,7 +2,7 @@ name: 'Setup QMK firmware'
 
 inputs:
   version:
-    default: '0.16.3'
+    default: '0.19.10'
     type: string
     required: false
   path:

--- a/qmk_firmware/keyboards/keyball/keyball39/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball39/config.h
@@ -77,5 +77,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // To squeeze firmware size
 #undef LOCKING_SUPPORT_ENABLE
 #undef LOCKING_RESYNC_ENABLE
-#define NO_ACTION_MACRO
-#define NO_ACTION_FUNCTION

--- a/qmk_firmware/keyboards/keyball/keyball39/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball39/config.h
@@ -20,13 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "config_common.h"
 
-// USB Device descriptor parameters
-#define VENDOR_ID           0x5957      // "YW" = Yowkees
-#define PRODUCT_ID          0x0200      
-#define DEVICE_VER          0x0001
-#define MANUFACTURER        Yowkees
-#define PRODUCT             Keyball39
-
 // Key matrix parameters
 #define MATRIX_ROWS         (4 * 2)  // split keyboard
 #define MATRIX_COLS         6

--- a/qmk_firmware/keyboards/keyball/keyball39/info.json
+++ b/qmk_firmware/keyboards/keyball/keyball39/info.json
@@ -2,7 +2,7 @@
     "usb": {
         "vid": "0x5957",
         "pid": "0x0200",
-        "device_version": "0.0.1",
+        "device_version": "1.0.0",
     },
     "manufacturer": "Yowkees",
     "keyboard_name": "Keyball39"

--- a/qmk_firmware/keyboards/keyball/keyball39/info.json
+++ b/qmk_firmware/keyboards/keyball/keyball39/info.json
@@ -1,0 +1,9 @@
+{
+    "usb": {
+        "vid": "0x5957",
+        "pid": "0x0200",
+        "device_version": "0.0.1",
+    },
+    "manufacturer": "Yowkees",
+    "keyboard_name": "Keyball39"
+}

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/default/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/default/keymap.c
@@ -27,7 +27,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_Q     , KC_W     , KC_E     , KC_R     , KC_T     ,                            KC_Y     , KC_U     , KC_I     , KC_O     , KC_P     ,
     KC_A     , KC_S     , KC_D     , KC_F     , KC_G     ,                            KC_H     , KC_J     , KC_K     , KC_L     , KC_MINS  ,
     KC_Z     , KC_X     , KC_C     , KC_V     , KC_B     ,                            KC_N     , KC_M     , KC_COMM  , KC_DOT   , KC_SLSH  ,
-    KC_LCTL  , KC_LGUI  , KC_LALT  ,LSFT_T(KC_LANG2),LT(1,KC_SPC),LT(3,KC_LANG1),KC_BSPC,LT(2,KC_ENT),LSFT_T(KC_LANG2),KC_RALT,KC_RGUI, KC_RSFT
+    KC_LCTL  , KC_LGUI  , KC_LALT  ,LSFT_T(KC_LNG2),LT(1,KC_SPC),LT(3,KC_LNG1),KC_BSPC,LT(2,KC_ENT),LSFT_T(KC_LNG2),KC_RALT,KC_RGUI, KC_RSFT
   ),
 
   [1] = LAYOUT_universal(
@@ -48,7 +48,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     RGB_TOG  , _______  , _______  , _______  , _______  ,                            RGB_M_P  , RGB_M_B  , RGB_M_R  , RGB_M_SW , RGB_M_SN ,
     RGB_MOD  , RGB_HUI  , RGB_SAI  , RGB_VAI  , SCRL_DVI ,                            RGB_M_K  , RGB_M_X  , RGB_M_G  , RGB_M_T  , RGB_M_TW ,
     RGB_RMOD , RGB_HUD  , RGB_SAD  , RGB_VAD  , SCRL_DVD ,                            CPI_D1K  , CPI_D100 , CPI_I100 , CPI_I1K  , KBC_SAVE ,
-    RESET    , KBC_RST  , _______  , _______  , _______  , _______  ,      _______ ,  _______  , _______  , _______  , KBC_RST  , RESET
+    QK_BOOT    , KBC_RST  , _______  , _______  , _______  , _______  ,      _______ ,  _______  , _______  , _______  , KBC_RST  , QK_BOOT
   ),
 };
 // clang-format on

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/develop/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/develop/keymap.c
@@ -34,7 +34,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     RGB_TOG  , _______  , _______  , _______  ,  _______  ,                            RGB_M_P  , RGB_M_B  , RGB_M_R  , RGB_M_SW , RGB_M_SN ,
     RGB_MOD  , RGB_HUI  , RGB_SAI  , RGB_VAI  ,  SCRL_DVI ,                            RGB_M_K  , RGB_M_X  , RGB_M_G  , RGB_M_T  , RGB_M_TW ,
     RGB_RMOD , RGB_HUD  , RGB_SAD  , RGB_VAD  ,  SCRL_DVD ,                            CPI_D1K  , CPI_D100 , CPI_I100 , CPI_I1K  , KBC_SAVE ,
-    RESET    , KBC_RST  , _______  , _______  ,  _______  , _______  ,      _______  , _______  , _______  , _______  , KBC_RST  , RESET
+    QK_BOOT    , KBC_RST  , _______  , _______  ,  _______  , _______  ,      _______  , _______  , _______  , _______  , KBC_RST  , QK_BOOT
   ),
 };
 // clang-format on

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/keymap.c
@@ -27,7 +27,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_Q     , KC_W     , KC_E     , KC_R     , KC_T     ,                            KC_Y     , KC_U     , KC_I     , KC_O     , KC_P     ,
     KC_A     , KC_S     , KC_D     , KC_F     , KC_G     ,                            KC_H     , KC_J     , KC_K     , KC_L     , KC_SCLN  ,
     KC_Z     , KC_X     , KC_C     , KC_V     , KC_B     ,                            KC_N     , KC_M     , KC_COMM  , KC_DOT   , KC_SLSH  ,
-    KC_LCTL  , KC_LGUI  , KC_LALT  ,LT(1,KC_LANG2),LT(2,KC_SPC),LT(3,KC_LANG1),KC_BSPC,LT(2,KC_ENT),LT(1,KC_LANG2),KC_RALT,KC_RGUI, KC_RSFT
+    KC_LCTL  , KC_LGUI  , KC_LALT  ,LT(1,KC_LNG2),LT(2,KC_SPC),LT(3,KC_LNG1),KC_BSPC,LT(2,KC_ENT),LT(1,KC_LNG2),KC_RALT,KC_RGUI, KC_RSFT
   ),
 
   [1] = LAYOUT_universal(
@@ -48,7 +48,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     RGB_TOG  , _______  , _______  , _______  ,  _______  ,                           RGB_M_P  , RGB_M_B  , RGB_M_R  , RGB_M_SW , RGB_M_SN ,
     RGB_MOD  , RGB_HUI  , RGB_SAI  , RGB_VAI  ,  SCRL_DVI ,                           RGB_M_K  , RGB_M_X  , RGB_M_G  , RGB_M_T  , RGB_M_TW ,
     RGB_RMOD , RGB_HUD  , RGB_SAD  , RGB_VAD  ,  SCRL_DVD ,                           CPI_D1K  , CPI_D100 , CPI_I100 , CPI_I1K  , KBC_SAVE ,
-    RESET    , KBC_RST  , _______  , _______  ,  _______  , _______  ,     _______  , _______  , _______  , _______  , KBC_RST  , RESET
+    QK_BOOT    , KBC_RST  , _______  , _______  ,  _______  , _______  ,     _______  , _______  , _______  , _______  , KBC_RST  , QK_BOOT
   ),
 };
 // clang-format on

--- a/qmk_firmware/keyboards/keyball/keyball44/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball44/config.h
@@ -77,5 +77,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // To squeeze firmware size
 #undef LOCKING_SUPPORT_ENABLE
 #undef LOCKING_RESYNC_ENABLE
-#define NO_ACTION_MACRO
-#define NO_ACTION_FUNCTION

--- a/qmk_firmware/keyboards/keyball/keyball44/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball44/config.h
@@ -20,13 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "config_common.h"
 
-// USB Device descriptor parameters
-#define VENDOR_ID           0x5957      // "YW" = Yowkees
-#define PRODUCT_ID          0x0400      
-#define DEVICE_VER          0x0001
-#define MANUFACTURER        Yowkees
-#define PRODUCT             Keyball44
-
 // Key matrix parameters
 #define MATRIX_ROWS         (4 * 2)  // split keyboard
 #define MATRIX_COLS         6

--- a/qmk_firmware/keyboards/keyball/keyball44/info.json
+++ b/qmk_firmware/keyboards/keyball/keyball44/info.json
@@ -1,0 +1,9 @@
+{
+    "usb": {
+        "vid": "0x5957",
+        "pid": "0x0400",
+        "device_version": "0.0.1"
+    }
+    "manufacturer": "Yowkees",
+    "keyboard_name": "Keyball44"
+}

--- a/qmk_firmware/keyboards/keyball/keyball44/info.json
+++ b/qmk_firmware/keyboards/keyball/keyball44/info.json
@@ -2,7 +2,7 @@
     "usb": {
         "vid": "0x5957",
         "pid": "0x0400",
-        "device_version": "0.0.1"
+        "device_version": "1.0.0"
     }
     "manufacturer": "Yowkees",
     "keyboard_name": "Keyball44"

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/default/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/default/keymap.c
@@ -27,7 +27,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_ESC   , KC_Q     , KC_W     , KC_E     , KC_R     , KC_T     ,                                        KC_Y     , KC_U     , KC_I     , KC_O     , KC_P     , KC_DEL   ,
     KC_TAB   , KC_A     , KC_S     , KC_D     , KC_F     , KC_G     ,                                        KC_H     , KC_J     , KC_K     , KC_L     , KC_SCLN  , S(KC_7)  ,
     KC_LSFT  , KC_Z     , KC_X     , KC_C     , KC_V     , KC_B     ,                                        KC_N     , KC_M     , KC_COMM  , KC_DOT   , KC_SLSH  , KC_INT1  ,
-              KC_LALT,KC_LGUI,LCTL_T(KC_LANG2)     ,LT(1,KC_SPC),LT(3,KC_LANG2),                  KC_BSPC,LT(2,KC_ENT), RCTL_T(KC_LANG2),     KC_RALT  , KC_PSCR
+              KC_LALT,KC_LGUI,LCTL_T(KC_LNG2)     ,LT(1,KC_SPC),LT(3,KC_LNG2),                  KC_BSPC,LT(2,KC_ENT), RCTL_T(KC_LNG2),     KC_RALT  , KC_PSCR
   ),
 
   [1] = LAYOUT_universal(
@@ -48,7 +48,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     RGB_TOG  , _______  , _______  , _______  , _______  , _______  ,                                        RGB_M_P  , RGB_M_B  , RGB_M_R  , RGB_M_SW , RGB_M_SN , RGB_M_K  ,
     RGB_MOD  , RGB_HUI  , RGB_SAI  , RGB_VAI  , _______  , SCRL_DVI ,                                        RGB_M_X  , RGB_M_G  , RGB_M_T  , RGB_M_TW , _______  , _______  ,
     RGB_RMOD , RGB_HUD  , RGB_SAD  , RGB_VAD  , _______  , SCRL_DVD ,                                        CPI_D1K  , CPI_D100 , CPI_I100 , CPI_I1K  , _______  , KBC_SAVE ,
-                  RESET    , KBC_RST  , _______  ,        _______  , _______  ,                   _______  , _______  , _______       , KBC_RST  , RESET
+                  QK_BOOT    , KBC_RST  , _______  ,        _______  , _______  ,                   _______  , _______  , _______       , KBC_RST  , QK_BOOT
   ),
 };
 // clang-format on

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/develop/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/develop/keymap.c
@@ -34,7 +34,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     RGB_TOG  , _______  , _______  , _______  , _______  , _______  ,                                        RGB_M_P  , RGB_M_B  , RGB_M_R  , RGB_M_SW , RGB_M_SN , RGB_M_K  ,
     RGB_MOD  , RGB_HUI  , RGB_SAI  , RGB_VAI  , _______  , SCRL_DVI ,                                        RGB_M_X  , RGB_M_G  , RGB_M_T  , RGB_M_TW , _______  , _______  ,
     RGB_RMOD , RGB_HUD  , RGB_SAD  , RGB_VAD  , _______  , SCRL_DVD ,                                        CPI_D1K  , CPI_D100 , CPI_I100 , CPI_I1K  , _______  , KBC_SAVE ,
-                    RESET    , KBC_RST  , _______  ,       _______  , _______     ,               _______  , _______  ,      _______  , KBC_RST  , RESET
+                    QK_BOOT    , KBC_RST  , _______  ,       _______  , _______     ,               _______  , _______  ,      _______  , KBC_RST  , QK_BOOT
   ),
 };
 // clang-format on

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/via/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/via/keymap.c
@@ -27,7 +27,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_ESC   , KC_Q     , KC_W     , KC_E     , KC_R     , KC_T     ,                                        KC_Y     , KC_U     , KC_I     , KC_O     , KC_P     , KC_DEL   ,
     KC_TAB   , KC_A     , KC_S     , KC_D     , KC_F     , KC_G     ,                                        KC_H     , KC_J     , KC_K     , KC_L     , KC_SCLN  , S(KC_7)  ,
     KC_LSFT  , KC_Z     , KC_X     , KC_C     , KC_V     , KC_B     ,                                        KC_N     , KC_M     , KC_COMM  , KC_DOT   , KC_SLSH  , KC_INT1  ,
-              KC_LALT,KC_LGUI,LCTL_T(KC_LANG2)     ,LT(1,KC_SPC),LT(3,KC_LANG1),                  KC_BSPC,LT(2,KC_ENT), RCTL_T(KC_LANG2),     KC_RALT  , KC_PSCR
+              KC_LALT,KC_LGUI,LCTL_T(KC_LNG2)     ,LT(1,KC_SPC),LT(3,KC_LNG1),                  KC_BSPC,LT(2,KC_ENT), RCTL_T(KC_LNG2),     KC_RALT  , KC_PSCR
   ),
 
   [1] = LAYOUT_universal(
@@ -48,7 +48,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     RGB_TOG  , _______  , _______  , _______  , _______  , _______  ,                                        RGB_M_P  , RGB_M_B  , RGB_M_R  , RGB_M_SW , RGB_M_SN , RGB_M_K  ,
     RGB_MOD  , RGB_HUI  , RGB_SAI  , RGB_VAI  , _______  , SCRL_DVI ,                                        RGB_M_X  , RGB_M_G  , RGB_M_T  , RGB_M_TW , _______  , _______  ,
     RGB_RMOD , RGB_HUD  , RGB_SAD  , RGB_VAD  , _______  , SCRL_DVD ,                                        CPI_D1K  , CPI_D100 , CPI_I100 , CPI_I1K  , _______  , KBC_SAVE ,
-                  RESET    , KBC_RST  , _______  ,        _______  , _______  ,                   _______  , _______  , _______       , KBC_RST  , RESET
+                  QK_BOOT    , KBC_RST  , _______  ,        _______  , _______  ,                   _______  , _______  , _______       , KBC_RST  , QK_BOOT
   ),
 };
 // clang-format on

--- a/qmk_firmware/keyboards/keyball/keyball46/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball46/config.h
@@ -78,5 +78,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // To squeeze firmware size
 #undef LOCKING_SUPPORT_ENABLE
 #undef LOCKING_RESYNC_ENABLE
-#define NO_ACTION_MACRO
-#define NO_ACTION_FUNCTION

--- a/qmk_firmware/keyboards/keyball/keyball46/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball46/config.h
@@ -20,13 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "config_common.h"
 
-// USB Device descriptor parameters
-#define VENDOR_ID           0x5957      // "YW" = Yowkees
-#define PRODUCT_ID          0x0001
-#define DEVICE_VER          0x0001
-#define MANUFACTURER        Yowkees
-#define PRODUCT             Keyball46
-
 // Key matrix parameters (Keyball61 is duplex matrix)
 #define MATRIX_ROWS         8
 #define MATRIX_COLS         6

--- a/qmk_firmware/keyboards/keyball/keyball46/info.json
+++ b/qmk_firmware/keyboards/keyball/keyball46/info.json
@@ -2,7 +2,7 @@
     "usb": {
         "vid": "0x5957",
         "pid": "0x0001",
-        "device_version": "0.0.1"
+        "device_version": "1.0.0"
     },
     "manufacturer": "Yowkees",
     "keyboard_name": "Keyball46",

--- a/qmk_firmware/keyboards/keyball/keyball46/info.json
+++ b/qmk_firmware/keyboards/keyball/keyball46/info.json
@@ -1,5 +1,11 @@
 {
-    "keyboard_name": "Keyball46 rev1",
+    "usb": {
+        "vid": "0x5957",
+        "pid": "0x0001",
+        "device_version": "0.0.1"
+    },
+    "manufacturer": "Yowkees",
+    "keyboard_name": "Keyball46",
     "url": "",
     "maintainer": "Yowkees",
     "width": 17.5,

--- a/qmk_firmware/keyboards/keyball/keyball46/keymaps/default/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball46/keymaps/default/keymap.c
@@ -34,10 +34,10 @@ enum keymap_layers {
 #define KC_R_ENT    LT(_RAISE, KC_ENT)
 
 // shift_t
-#define KC_S_EN     LSFT_T(KC_LANG2)
+#define KC_S_EN     LSFT_T(KC_LNG2)
 
 // original
-#define KC_A_JA     LT(_BALL, KC_LANG1)     // cmd or adjust
+#define KC_A_JA     LT(_BALL, KC_LNG1)     // cmd or adjust
 #define KC_AL_CP    MT(MOD_LALT, KC_CAPS)   // alt or caps lock
 #define KC_G_BS     MT(MOD_LGUI, KC_BSPC)   // command or back space
 #define KC_G_DEL    MT(MOD_LGUI, KC_DEL)    // command or delete
@@ -92,7 +92,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   //|--------+--------+--------+--------+--------+--------'                    |--------+--------+--------+--------+--------+--------|
      RGB_RMOD, RGB_HUD, RGB_SAD, RGB_VAD, _______,                               _______, CPI_D1K,CPI_D100,CPI_I100, CPI_I1K,KBC_SAVE,
   //|--------+--------+--------+--------+--------+-------+--------.            `--------+--------+--------+--------+--------+--------|
-        RESET, EEP_RST,    _______,    _______,   _______, _______,                _______,SCRL_DVD,       SCRL_DVI, _______, KBC_RST
+        QK_BOOT, EE_CLR,    _______,    _______,   _______, _______,                _______,SCRL_DVD,       SCRL_DVI, _______, KBC_RST
   //`--------+--------'  `--------'  `--------' `--------+--------'              `--------+--------'      `--------+--------+--------'
   ),
 

--- a/qmk_firmware/keyboards/keyball/keyball46/keymaps/develop/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball46/keymaps/develop/keymap.c
@@ -34,7 +34,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     RGB_TOG  , _______  , _______  , _______  , _______  , _______  ,           RGB_M_P  , RGB_M_B  , RGB_M_R  , RGB_M_SW , RGB_M_SN , RGB_M_K  ,
     RGB_MOD  , RGB_HUI  , RGB_SAI  , RGB_VAI  , _______  , _______  ,           RGB_M_X  , RGB_M_G  , RGB_M_T  , RGB_M_TW , _______  , _______  ,
     RGB_RMOD , RGB_HUD  , RGB_SAD  , RGB_VAD  , _______  , _______  ,           _______  , CPI_D1K  , CPI_D100 , CPI_I100 , CPI_I1K  , KBC_SAVE ,
-    RESET    , EEP_RST  , _______  , _______  , _______  , _______  ,           _______  , _______  , SCRL_DVD , SCRL_DVI , _______  , KBC_RST
+    QK_BOOT    , EE_CLR  , _______  , _______  , _______  , _______  ,           _______  , _______  , SCRL_DVD , SCRL_DVI , _______  , KBC_RST
   ),
 };
 // clang-format on

--- a/qmk_firmware/keyboards/keyball/keyball46/keymaps/via/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball46/keymaps/via/keymap.c
@@ -34,10 +34,10 @@ enum keymap_layers {
 #define KC_R_ENT    LT(_RAISE, KC_ENT)
 
 // shift_t
-#define KC_S_EN     LSFT_T(KC_LANG2)
+#define KC_S_EN     LSFT_T(KC_LNG2)
 
 // original
-#define KC_A_JA     LT(_BALL, KC_LANG1)     // cmd or adjust
+#define KC_A_JA     LT(_BALL, KC_LNG1)     // cmd or adjust
 #define KC_AL_CP    MT(MOD_LALT, KC_CAPS)   // alt or caps lock
 #define KC_G_BS     MT(MOD_LGUI, KC_BSPC)   // command or back space
 #define KC_G_DEL    MT(MOD_LGUI, KC_DEL)    // command or delete
@@ -92,7 +92,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   //|--------+--------+--------+--------+--------+--------'                    |--------+--------+--------+--------+--------+--------|
      RGB_RMOD, RGB_HUD, RGB_SAD, RGB_VAD, _______,                               _______, CPI_D1K,CPI_D100,CPI_I100, CPI_I1K,KBC_SAVE,
   //|--------+--------+--------+--------+--------+-------+--------.            `--------+--------+--------+--------+--------+--------|
-        RESET, EEP_RST,    _______,    _______,   _______, _______,                _______,SCRL_DVD,       SCRL_DVI, _______, KBC_RST
+        QK_BOOT, EE_CLR,    _______,    _______,   _______, _______,                _______,SCRL_DVD,       SCRL_DVI, _______, KBC_RST
   //`--------+--------'  `--------'  `--------' `--------+--------'              `--------+--------'      `--------+--------+--------'
   ),
 

--- a/qmk_firmware/keyboards/keyball/keyball46/keymaps/via_Both/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball46/keymaps/via_Both/keymap.c
@@ -34,10 +34,10 @@ enum keymap_layers {
 #define KC_R_ENT    LT(_RAISE, KC_ENT)
 
 // shift_t
-#define KC_S_EN     LSFT_T(KC_LANG2)
+#define KC_S_EN     LSFT_T(KC_LNG2)
 
 // original
-#define KC_A_JA     LT(_BALL, KC_LANG1)     // cmd or adjust
+#define KC_A_JA     LT(_BALL, KC_LNG1)     // cmd or adjust
 #define KC_AL_CP    MT(MOD_LALT, KC_CAPS)   // alt or caps lock
 #define KC_G_BS     MT(MOD_LGUI, KC_BSPC)   // command or back space
 #define KC_G_DEL    MT(MOD_LGUI, KC_DEL)    // command or delete
@@ -68,7 +68,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
       KC_LSFT, KC_SLSH,    KC_1,    KC_2,    KC_3,  KC_EQL,                       KC_GRV,  KC_DQT, KC_QUOT, KC_CIRC, KC_TILD, KC_RSFT,
   //|--------+--------+--------+--------+--------+--------'                    `--------+--------+--------+--------+--------+--------|
-       KC_ESC,  KC_GRV,    KC_0,     KC_LANG2,KC_A_DEL,                              _______, _______,      KC_LPRN, KC_RPRN, KC_BSLS
+       KC_ESC,  KC_GRV,    KC_0,     KC_LNG2,KC_A_DEL,                              _______, _______,      KC_LPRN, KC_RPRN, KC_BSLS
   //`--------+--------+--------'    `--------+--------'                            `--------+--------'    `--------+--------+--------'
   ),
 
@@ -80,7 +80,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
       KC_LSFT, _______, _______, KC_DOWN, _______, _______,                      _______, _______, KC_PGDN, _______, _______, KC_RSFT,
   //|--------+--------+--------+--------+--------+--------'                    `--------+--------+--------+--------+--------+--------|
-       KC_ESC,  KC_GRV, KC_LALT,      _______, _______,                              KC_A_BS,KC_LANG1,      KC_LPRN, KC_RPRN, KC_BSLS
+       KC_ESC,  KC_GRV, KC_LALT,      _______, _______,                              KC_A_BS,KC_LNG1,      KC_LPRN, KC_RPRN, KC_BSLS
   //`--------+--------+--------'    `--------+--------'                            `--------+--------'    `--------+--------+--------'
   ),
 
@@ -92,7 +92,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
       RGB_MOD, RGB_HUD, RGB_SAD, RGB_VAD, _______, _______,                      _______, CPI_D1K,CPI_D100,CPI_I100, CPI_I1K,KBC_SAVE,
   //|--------+--------+--------+--------+--------+--------'                    `--------+--------+--------+--------+--------+--------|
-        RESET, EEP_RST, _______,      _______, _______,                              _______,SCRL_DVD,     SCRL_DVI, _______, KBC_RST
+        QK_BOOT, EE_CLR, _______,      _______, _______,                              _______,SCRL_DVD,     SCRL_DVI, _______, KBC_RST
   //`--------+--------+--------'    `--------+--------'                            `--------+--------'    `--------+--------+--------'
   ),
 

--- a/qmk_firmware/keyboards/keyball/keyball46/keymaps/via_Left/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball46/keymaps/via_Left/keymap.c
@@ -34,10 +34,10 @@ enum keymap_layers {
 #define KC_R_ENT    LT(_RAISE, KC_ENT)
 
 // shift_t
-#define KC_S_EN     LSFT_T(KC_LANG2)
+#define KC_S_EN     LSFT_T(KC_LNG2)
 
 // original
-#define KC_A_JA     LT(_BALL, KC_LANG1)     // cmd or adjust
+#define KC_A_JA     LT(_BALL, KC_LNG1)     // cmd or adjust
 #define KC_AL_CP    MT(MOD_LALT, KC_CAPS)   // alt or caps lock
 #define KC_G_BS     MT(MOD_LGUI, KC_BSPC)   // command or back space
 #define KC_G_DEL    MT(MOD_LGUI, KC_DEL)    // command or delete
@@ -92,7 +92,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   //|--------+--------+--------+--------+--------+--------|                    `--------+--------+--------+--------+--------+--------|
      RGB_RMOD, RGB_HUD, RGB_SAD, RGB_VAD, _______, _______,                               CPI_D1K,CPI_D100,CPI_I100, CPI_I1K,KBC_SAVE,
   //|--------+--------+--------+--------+--------+--------'            ,--------+-------+--------+--------+--------+--------+--------|
-        RESET, EEP_RST, _______,        _______, _______,                _______, _______,  SCRL_DVD,   SCRL_DVI,    _______, KBC_RST
+        QK_BOOT, EE_CLR, _______,        _______, _______,                _______, _______,  SCRL_DVD,   SCRL_DVI,    _______, KBC_RST
   //`--------+--------+--------'      `--------+--------'              `--------+--------' `--------'  `--------'  `--------+--------'
   ),
 

--- a/qmk_firmware/keyboards/keyball/keyball61/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball61/config.h
@@ -76,5 +76,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // To squeeze firmware size
 #undef LOCKING_SUPPORT_ENABLE
 #undef LOCKING_RESYNC_ENABLE
-#define NO_ACTION_MACRO
-#define NO_ACTION_FUNCTION

--- a/qmk_firmware/keyboards/keyball/keyball61/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball61/config.h
@@ -20,13 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "config_common.h"
 
-// USB Device descriptor parameters
-#define VENDOR_ID           0x5957     // "YW" = Yowkees
-#define PRODUCT_ID          0x0100
-#define DEVICE_VER          0x0001
-#define MANUFACTURER        Yowkees
-#define PRODUCT             Keyball61
-
 // Key matrix parameters (Keyball61 is duplex matrix)
 #define MATRIX_ROWS         (5 * 2)  // split keyboard
 #define MATRIX_COLS         (4 * 2)  // duplex matrix

--- a/qmk_firmware/keyboards/keyball/keyball61/info.json
+++ b/qmk_firmware/keyboards/keyball/keyball61/info.json
@@ -1,0 +1,9 @@
+{
+    "usb": {
+        "vid": "0x5957",
+        "pid": "0x0100",
+        "device_version": "0.0.1",
+    },
+    "manufacturer": "Yowkees",
+    "keyboard_name": "Keyball61"
+}

--- a/qmk_firmware/keyboards/keyball/keyball61/info.json
+++ b/qmk_firmware/keyboards/keyball/keyball61/info.json
@@ -2,7 +2,7 @@
     "usb": {
         "vid": "0x5957",
         "pid": "0x0100",
-        "device_version": "0.0.1",
+        "device_version": "1.0.0",
     },
     "manufacturer": "Yowkees",
     "keyboard_name": "Keyball61"

--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/default/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/default/keymap.c
@@ -27,7 +27,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_DEL   , KC_Q     , KC_W     , KC_E     , KC_R     , KC_T     ,                                  KC_Y     , KC_U     , KC_I     , KC_O     , KC_P     , KC_INT3  ,
     KC_TAB   , KC_A     , KC_S     , KC_D     , KC_F     , KC_G     ,                                  KC_H     , KC_J     , KC_K     , KC_L     , KC_SCLN  , S(KC_7)  ,
     MO(1)    , KC_Z     , KC_X     , KC_C     , KC_V     , KC_B     , KC_RBRC  ,              KC_NUHS, KC_N     , KC_M     , KC_COMM  , KC_DOT   , KC_SLSH  , KC_RSFT  ,
-    _______  , KC_LCTL  , KC_LALT  , KC_LGUI,LT(1,KC_LANG2),LT(2,KC_SPC),LT(3,KC_LANG1),    KC_BSPC,LT(2,KC_ENT),LT(1,KC_LANG2),KC_RGUI, _______ , KC_RALT  , KC_PSCR
+    _______  , KC_LCTL  , KC_LALT  , KC_LGUI,LT(1,KC_LNG2),LT(2,KC_SPC),LT(3,KC_LNG1),    KC_BSPC,LT(2,KC_ENT),LT(1,KC_LNG2),KC_RGUI, _______ , KC_RALT  , KC_PSCR
   ),
 
   [1] = LAYOUT_universal(
@@ -50,8 +50,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     RGB_TOG  , _______  , _______  , _______  , _______  , _______  ,                                  RGB_M_P  , RGB_M_B  , RGB_M_R  , RGB_M_SW , RGB_M_SN , RGB_M_K  ,
     RGB_MOD  , RGB_HUI  , RGB_SAI  , RGB_VAI  , _______  , _______  ,                                  RGB_M_X  , RGB_M_G  , RGB_M_T  , RGB_M_TW , _______  , _______  ,
     RGB_RMOD , RGB_HUD  , RGB_SAD  , RGB_VAD  , _______  , _______  ,                                  CPI_D1K  , CPI_D100 , CPI_I100 , CPI_I1K  , KBC_SAVE , KBC_RST  ,
-    _______  , _______  , SCRL_DVD , SCRL_DVI , SCRL_MO  , SCRL_TO  , EEP_RST  ,            EEP_RST  , KC_HOME  , KC_PGDN  , KC_PGUP  , KC_END   , _______  , _______  ,
-    RESET    , _______  , KC_LEFT  , KC_DOWN  , KC_UP    , KC_RGHT  , _______  ,            _______  , KC_BSPC  , _______  , _______  , _______  , _______  , RESET
+    _______  , _______  , SCRL_DVD , SCRL_DVI , SCRL_MO  , SCRL_TO  , EE_CLR  ,            EE_CLR  , KC_HOME  , KC_PGDN  , KC_PGUP  , KC_END   , _______  , _______  ,
+    QK_BOOT    , _______  , KC_LEFT  , KC_DOWN  , KC_UP    , KC_RGHT  , _______  ,            _______  , KC_BSPC  , _______  , _______  , _______  , _______  , QK_BOOT
   ),
 };
 // clang-format on

--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/develop/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/develop/keymap.c
@@ -35,8 +35,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     RGB_TOG  , _______  , _______  , _______  , _______  , _______  ,                            RGB_M_P  , RGB_M_B  , RGB_M_R  , RGB_M_SW , RGB_M_SN , RGB_M_K  ,
     RGB_MOD  , RGB_HUI  , RGB_SAI  , RGB_VAI  , _______  , _______  ,                            RGB_M_X  , RGB_M_G  , RGB_M_T  , RGB_M_TW , _______  , _______  ,
     RGB_RMOD , RGB_HUD  , RGB_SAD  , RGB_VAD  , _______  , _______  ,                            CPI_D1K  , CPI_D100 , CPI_I100 , CPI_I1K  , KBC_SAVE , KBC_RST  ,
-    _______  , _______  , SCRL_DVD , SCRL_DVI , SCRL_MO  , SCRL_TO  , EEP_RST  ,      EEP_RST  , _______  , _______  , _______  , _______  , _______  , _______  ,
-    RESET    , _______  , _______  , _______  , _______  , _______  , _______  ,      _______  , _______  , _______  , _______  , _______  , _______  , RESET
+    _______  , _______  , SCRL_DVD , SCRL_DVI , SCRL_MO  , SCRL_TO  , EE_CLR  ,      EE_CLR  , _______  , _______  , _______  , _______  , _______  , _______  ,
+    QK_BOOT    , _______  , _______  , _______  , _______  , _______  , _______  ,      _______  , _______  , _______  , _______  , _______  , _______  , QK_BOOT
   ),
 };
 // clang-format on

--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/via/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/via/keymap.c
@@ -27,7 +27,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_DEL   , KC_Q     , KC_W     , KC_E     , KC_R     , KC_T     ,                                  KC_Y     , KC_U     , KC_I     , KC_O     , KC_P     , KC_INT3  ,
     KC_TAB   , KC_A     , KC_S     , KC_D     , KC_F     , KC_G     ,                                  KC_H     , KC_J     , KC_K     , KC_L     , KC_SCLN  , S(KC_7)  ,
     MO(1)    , KC_Z     , KC_X     , KC_C     , KC_V     , KC_B     , KC_RBRC  ,              KC_NUHS, KC_N     , KC_M     , KC_COMM  , KC_DOT   , KC_SLSH  , KC_RSFT  ,
-    _______  , KC_LCTL  , KC_LALT  , KC_LGUI,LT(1,KC_LANG2),LT(2,KC_SPC),LT(3,KC_LANG1),    KC_BSPC,LT(2,KC_ENT),LT(1,KC_LANG2),KC_RGUI, _______ , KC_RALT  , KC_PSCR
+    _______  , KC_LCTL  , KC_LALT  , KC_LGUI,LT(1,KC_LNG2),LT(2,KC_SPC),LT(3,KC_LNG1),    KC_BSPC,LT(2,KC_ENT),LT(1,KC_LNG2),KC_RGUI, _______ , KC_RALT  , KC_PSCR
   ),
 
   [1] = LAYOUT_universal(
@@ -50,8 +50,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     RGB_TOG  , _______  , _______  , _______  , _______  , _______  ,                                  RGB_M_P  , RGB_M_B  , RGB_M_R  , RGB_M_SW , RGB_M_SN , RGB_M_K  ,
     RGB_MOD  , RGB_HUI  , RGB_SAI  , RGB_VAI  , _______  , _______  ,                                  RGB_M_X  , RGB_M_G  , RGB_M_T  , RGB_M_TW , _______  , _______  ,
     RGB_RMOD , RGB_HUD  , RGB_SAD  , RGB_VAD  , _______  , _______  ,                                  CPI_D1K  , CPI_D100 , CPI_I100 , CPI_I1K  , KBC_SAVE , KBC_RST  ,
-    _______  , _______  , SCRL_DVD , SCRL_DVI , SCRL_MO  , SCRL_TO  , EEP_RST  ,            EEP_RST  , KC_HOME  , KC_PGDN  , KC_PGUP  , KC_END   , _______  , _______  ,
-    RESET    , _______  , KC_LEFT  , KC_DOWN  , KC_UP    , KC_RGHT  , _______  ,            _______  , KC_BSPC  , _______  , _______  , _______  , _______  , RESET
+    _______  , _______  , SCRL_DVD , SCRL_DVI , SCRL_MO  , SCRL_TO  , EE_CLR  ,            EE_CLR  , KC_HOME  , KC_PGDN  , KC_PGUP  , KC_END   , _______  , _______  ,
+    QK_BOOT    , _______  , KC_LEFT  , KC_DOWN  , KC_UP    , KC_RGHT  , _______  ,            _______  , KC_BSPC  , _______  , _______  , _______  , _______  , QK_BOOT
   ),
 };
 // clang-format on

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
@@ -500,8 +500,8 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
         // process KC_MS_BTN1~8 by myself
         // See process_action() in quantum/action.c for details.
         case KC_MS_BTN1 ... KC_MS_BTN8: {
-            extern void register_button(bool, enum mouse_buttons);
-            register_button(record->event.pressed, MOUSE_BTN_MASK(keycode - KC_MS_BTN1));
+            extern void register_mouse(uint8_t mouse_keycode, bool pressed);
+            register_mouse(keycode, record->event.pressed);
             // to apply QK_MODS actions, allow to process others.
             return true;
         }

--- a/qmk_firmware/keyboards/keyball/one47/config.h
+++ b/qmk_firmware/keyboards/keyball/one47/config.h
@@ -20,13 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "config_common.h"
 
-// USB Device descriptor parameters
-#define VENDOR_ID           0x5957     // "YW" = Yowkees
-#define PRODUCT_ID          0x0300
-#define DEVICE_VER          0x0001
-#define MANUFACTURER        Yowkees
-#define PRODUCT             KeyballONE47
-
 // Key matrix parameters (KeyballONE46 is duplex matrix)
 #define MATRIX_ROWS         (4)      // split keyboard
 #define MATRIX_COLS         (6 * 2)  // duplex matrix
@@ -64,5 +57,3 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // To squeeze firmware size
 #undef LOCKING_SUPPORT_ENABLE
 #undef LOCKING_RESYNC_ENABLE
-#define NO_ACTION_MACRO
-#define NO_ACTION_FUNCTION

--- a/qmk_firmware/keyboards/keyball/one47/info.json
+++ b/qmk_firmware/keyboards/keyball/one47/info.json
@@ -1,0 +1,9 @@
+{
+    "usb": {
+        "vid": "0x5957",
+        "pid": "0x0300",
+        "device_version": "0.1.0"
+    },
+    "manufacturer": "Yowkees",
+    "keyboard_name": "KeyballONE47"
+}

--- a/qmk_firmware/keyboards/keyball/one47/keymaps/default/keymap.c
+++ b/qmk_firmware/keyboards/keyball/one47/keymaps/default/keymap.c
@@ -26,7 +26,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_DEL   , KC_Q     , KC_W     , KC_E     , KC_R     , KC_T     ,                            KC_Y     , KC_U     , KC_I     , KC_O     , KC_P     , KC_INT3  ,
     KC_TAB   , KC_A     , KC_S     , KC_D     , KC_F     , KC_G     ,                            KC_H     , KC_J     , KC_K     , KC_L     , KC_SCLN  , S(KC_7)  ,
     MO(1)    , KC_Z     , KC_X     , KC_C     , KC_V     , KC_B     , KC_RBRC  ,      KC_NUHS,   KC_N     , KC_M     , KC_COMM  , KC_DOT   , KC_SLSH  , KC_RSFT  ,
-             KC_LCTL , KC_LALT ,KC_LGUI ,LT(1,KC_LANG2),LT(2,KC_SPC),LT(3,KC_LANG1),  KC_BSPC,   KC_ENT   ,                                  KC_RALT
+             KC_LCTL , KC_LALT ,KC_LGUI ,LT(1,KC_LNG2),LT(2,KC_SPC),LT(3,KC_LNG1),  KC_BSPC,   KC_ENT   ,                                  KC_RALT
   ),
 
   [1] = LAYOUT_right_ball(
@@ -46,7 +46,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [3] = LAYOUT_right_ball(
     RGB_TOG  , _______  , _______  , _______  , _______  , _______  ,                            RGB_M_P  , RGB_M_B  , RGB_M_R  , RGB_M_SW , RGB_M_SN , RGB_M_K  ,
     RGB_MOD  , RGB_HUI  , RGB_SAI  , RGB_VAI  , _______  , SCRL_DVI ,                            RGB_M_X  , RGB_M_G  , RGB_M_T  , RGB_M_TW , _______  , _______  ,
-    RGB_RMOD , RGB_HUD  , RGB_SAD  , RGB_VAD  , _______  , SCRL_DVD , RESET    ,      EEP_RST  , CPI_D1K  , CPI_D100 , CPI_I100 , CPI_I1K  , KBC_SAVE , KBC_RST  ,
+    RGB_RMOD , RGB_HUD  , RGB_SAD  , RGB_VAD  , _______  , SCRL_DVD , QK_BOOT    ,      EE_CLR  , CPI_D1K  , CPI_D100 , CPI_I100 , CPI_I1K  , KBC_SAVE , KBC_RST  ,
                _______  , _______  , _______  , _______  , _______  ,   _______  ,  _______    , _______  ,                                  _______
   ),
 };

--- a/qmk_firmware/keyboards/keyball/one47/keymaps/develop/keymap.c
+++ b/qmk_firmware/keyboards/keyball/one47/keymaps/develop/keymap.c
@@ -33,7 +33,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [1] = LAYOUT_right_ball(
     RGB_TOG  , _______  , _______  , _______  , _______  , _______  ,                            RGB_M_P  , RGB_M_B  , RGB_M_R  , RGB_M_SW , RGB_M_SN , RGB_M_K  ,
     RGB_MOD  , RGB_HUI  , RGB_SAI  , RGB_VAI  , _______  , SCRL_DVI ,                            RGB_M_X  , RGB_M_G  , RGB_M_T  , RGB_M_TW , _______  , _______  ,
-    RGB_RMOD , RGB_HUD  , RGB_SAD  , RGB_VAD  , _______  , SCRL_DVD , RESET    ,      EEP_RST  , CPI_D1K  , CPI_D100 , CPI_I100 , CPI_I1K  , KBC_SAVE , KBC_RST  ,
+    RGB_RMOD , RGB_HUD  , RGB_SAD  , RGB_VAD  , _______  , SCRL_DVD , QK_BOOT    ,      EE_CLR  , CPI_D1K  , CPI_D100 , CPI_I100 , CPI_I1K  , KBC_SAVE , KBC_RST  ,
                _______  , _______  , _______  , _______  , _______  ,   _______  ,  _______    , _______  ,                                  _______
   ),
 };

--- a/qmk_firmware/keyboards/keyball/one47/keymaps/via/keymap.c
+++ b/qmk_firmware/keyboards/keyball/one47/keymaps/via/keymap.c
@@ -26,7 +26,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_DEL   , KC_Q     , KC_W     , KC_E     , KC_R     , KC_T     ,                            KC_Y     , KC_U     , KC_I     , KC_O     , KC_P     , KC_INT3  ,
     KC_TAB   , KC_A     , KC_S     , KC_D     , KC_F     , KC_G     ,                            KC_H     , KC_J     , KC_K     , KC_L     , KC_SCLN  , S(KC_7)  ,
     MO(1)    , KC_Z     , KC_X     , KC_C     , KC_V     , KC_B     , KC_RBRC  ,      KC_NUHS,   KC_N     , KC_M     , KC_COMM  , KC_DOT   , KC_SLSH  , KC_RSFT  ,
-             KC_LCTL , KC_LALT ,KC_LGUI ,LT(1,KC_LANG2),LT(2,KC_SPC),LT(3,KC_LANG1),  KC_BSPC,   KC_ENT   ,                                  KC_RALT
+             KC_LCTL , KC_LALT ,KC_LGUI ,LT(1,KC_LNG2),LT(2,KC_SPC),LT(3,KC_LNG1),  KC_BSPC,   KC_ENT   ,                                  KC_RALT
   ),
 
   [1] = LAYOUT_right_ball(
@@ -46,7 +46,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [3] = LAYOUT_right_ball(
     RGB_TOG  , _______  , _______  , _______  , _______  , _______  ,                            RGB_M_P  , RGB_M_B  , RGB_M_R  , RGB_M_SW , RGB_M_SN , RGB_M_K  ,
     RGB_MOD  , RGB_HUI  , RGB_SAI  , RGB_VAI  , _______  , SCRL_DVI ,                            RGB_M_X  , RGB_M_G  , RGB_M_T  , RGB_M_TW , _______  , _______  ,
-    RGB_RMOD , RGB_HUD  , RGB_SAD  , RGB_VAD  , _______  , SCRL_DVD , RESET    ,      EEP_RST  , CPI_D1K  , CPI_D100 , CPI_I100 , CPI_I1K  , KBC_SAVE , KBC_RST  ,
+    RGB_RMOD , RGB_HUD  , RGB_SAD  , RGB_VAD  , _______  , SCRL_DVD , QK_BOOT    ,      EE_CLR  , CPI_D1K  , CPI_D100 , CPI_I100 , CPI_I1K  , KBC_SAVE , KBC_RST  ,
                _______  , _______  , _______  , _______  , _______  ,   _______  ,  _______    , _______  ,                                  _______
   ),
 };


### PR DESCRIPTION
Includes (done + planned): 

* https://github.com/Yowkees/keyball/pull/182
* Changes of GHA configuration
* Keyball46 care
* One47 care

Issues:
* [x] fix for Keyball46
* [x] fix for One47
* [x] stop to use `continue-on-error: true` in GHA workflow #184
* [x] bump up device versions to 1.0.0 or above.
* [x] Remap-app supports QMK firmware 0.19.x or above
* [ ] Switch QMK to 0.22.2 or abobe

This branch will be merged to main branch when Remap-app supports QMK firmware 0.19.x or above.