### PR TITLE
implement user keys for remap/VIA

### DIFF
--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
@@ -71,7 +71,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // Types
 
 enum keyball_keycodes {
+#ifdef VIA_ENABLED
+    KBC_RST = USER00, // Keyball configuration: reset to default
+#else
     KBC_RST = SAFE_RANGE, // Keyball configuration: reset to default
+#endif
     KBC_SAVE,             // Keyball configuration: save to EEPROM
 
     CPI_I100, // CPI +100 CPI
@@ -88,6 +92,8 @@ enum keyball_keycodes {
 
     KEYBALL_SAFE_RANGE,
 };
+
+
 
 typedef union {
     uint32_t raw;


### PR DESCRIPTION
## タイトル

VIA USER KEYS 対応

## 目的

- REMAPにおいてCPI調整やスクロール調整のキーを設定する際、コードを直接入力する代わりにVIA USER KEYSからD&Dで設定できます。
- 副次的に、qmkのバージョンによって発生するキーコードのズレが解消されます。

## 懸念点

今後REMAPが最新のqmkに追随した際に、割当てたコードの変更が必要になる可能性があります。

## キー対応表

| Keycode | VIA USER KEYS |
|---------|------------|
| KBC_RST | USER 0 |
| KBC_SAV | USER 1 |
| CPI_I100 | USER 2 |
| CPI_D100 | USER 3 |
| CPI_I1K | USER 4 |
| CPI_D1K | USER 5 |
| SCRL_TO | USER 6 |
| SCRL_MO | USER 7 |
| SCRL_DVI | USER 8 |
| SCRL_DVD | USER 9 |