### PR TITLE
Remove USB detect and fix typo in README

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball44/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball44/config.h
@@ -39,8 +39,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // Split parameters
 #define SOFT_SERIAL_PIN         D2
 #define SPLIT_HAND_MATRIX_GRID  F7, D4
-#define SPLIT_USB_DETECT
-#define SPLIT_USB_TIMEOUT       500
 
 #define SPLIT_TRANSACTION_IDS_KB KEYBALL_GET_INFO, KEYBALL_GET_MOTION, KEYBALL_SET_CPI
 

--- a/qmk_firmware/keyboards/keyball/readme.md
+++ b/qmk_firmware/keyboards/keyball/readme.md
@@ -27,10 +27,10 @@ See each directories for each keyboards in a table above.
 2. Check out [qmk/qmk_firmware](https://github.com/qmk/qmk_firmware/) repository in another place.
 
     ```console
-    $ git clone https://github.com/qmk/qmk_firmware.git --depth 1 --recurse-submodules --shallow-submodules -b 0.15.13 qmk
+    $ git clone https://github.com/qmk/qmk_firmware.git --depth 1 --recurse-submodules --shallow-submodules -b 0.16.3 qmk
     ```
 
-    Currently Keyball firmwares are verified to compile with QMK 0.16.13
+    Currently Keyball firmwares are verified to compile with QMK 0.16.3
 
 3. Create a symbolic link to this `keyball/` directory from [qmk/qmk_firmware]'s `keyboards/` directory.
 


### PR DESCRIPTION
## What
This PR fixes two things:

- Since the keyball already mentions the usage of PRO MICRO, it's better to remove the SPLIT_USB_DETECT as it can have undesired behaviours on the delegation detection. PRO MICRO [already uses the VBUS for delegation](https://github.com/qmk/qmk_firmware/blob/master/docs/feature_split_keyboard.md#hardware-considerations-and-mods)
  - One example is when the two halves have the keyball logo because of not being able to delegate the master/slave relation.
  - I believe this can be applied to other keyballs but I don't have them to test 😅 . E.g. https://github.com/Yowkees/keyball/issues/169#issuecomment-1402824492 	
- README had the wrong latest tested QMK information. Small typo fix there.

