### PR TITLE
Show layer information in OLED

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/default/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/default/keymap.c
@@ -64,6 +64,7 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 #    include "lib/oledkit/oledkit.h"
 
 void oledkit_render_info_user(void) {
+    keyball_oled_render_layerinfo();
     keyball_oled_render_keyinfo();
     keyball_oled_render_ballinfo();
 }

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/default/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/default/keymap.c
@@ -64,8 +64,8 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 #    include "lib/oledkit/oledkit.h"
 
 void oledkit_render_info_user(void) {
-    keyball_oled_render_layerinfo();
     keyball_oled_render_keyinfo();
     keyball_oled_render_ballinfo();
+    keyball_oled_render_layerinfo();
 }
 #endif

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/test/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/test/keymap.c
@@ -46,5 +46,6 @@ void keyboard_post_init_user() {
 void oledkit_render_info_user(void) {
     keyball_oled_render_keyinfo();
     keyball_oled_render_ballinfo();
+    keyball_oled_render_layerinfo();
 }
 #endif

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/keymap.c
@@ -64,6 +64,7 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 #    include "lib/oledkit/oledkit.h"
 
 void oledkit_render_info_user(void) {
+    keyball_oled_render_layerinfo();
     keyball_oled_render_keyinfo();
     keyball_oled_render_ballinfo();
 }

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/keymap.c
@@ -64,8 +64,8 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 #    include "lib/oledkit/oledkit.h"
 
 void oledkit_render_info_user(void) {
-    keyball_oled_render_layerinfo();
     keyball_oled_render_keyinfo();
     keyball_oled_render_ballinfo();
+    keyball_oled_render_layerinfo();
 }
 #endif

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/default/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/default/keymap.c
@@ -66,5 +66,6 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 void oledkit_render_info_user(void) {
     keyball_oled_render_keyinfo();
     keyball_oled_render_ballinfo();
+    keyball_oled_render_layerinfo();
 }
 #endif

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/develop/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/develop/keymap.c
@@ -46,5 +46,6 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 void oledkit_render_info_user(void) {
     keyball_oled_render_keyinfo();
     keyball_oled_render_ballinfo();
+    keyball_oled_render_layerinfo();
 }
 #endif

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/test/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/test/keymap.c
@@ -46,5 +46,6 @@ void keyboard_post_init_user() {
 void oledkit_render_info_user(void) {
     keyball_oled_render_keyinfo();
     keyball_oled_render_ballinfo();
+    keyball_oled_render_layerinfo();
 }
 #endif

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/via/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/via/keymap.c
@@ -66,5 +66,6 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 void oledkit_render_info_user(void) {
     keyball_oled_render_keyinfo();
     keyball_oled_render_ballinfo();
+    keyball_oled_render_layerinfo();
 }
 #endif

--- a/qmk_firmware/keyboards/keyball/keyball46/keymaps/default/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball46/keymaps/default/keymap.c
@@ -112,26 +112,6 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 void oledkit_render_info_user(void) {
     keyball_oled_render_keyinfo();
     keyball_oled_render_ballinfo();
-
-    const char *n;
-    switch (get_highest_layer(layer_state)) {
-        case _QWERTY:
-            n = PSTR("Default");
-            break;
-        case _RAISE:
-            n = PSTR("Raise");
-            break;
-        case _LOWER:
-            n = PSTR("Lower");
-            break;
-        case _BALL:
-            n = PSTR("Adjust");
-            break;
-        default:
-            n = PSTR("Undefined");
-            break;
-    }
-    oled_write_P(PSTR("Layer: "), false);
-    oled_write_ln_P(n, false);
+    keyball_oled_render_layerinfo();
 }
 #endif

--- a/qmk_firmware/keyboards/keyball/keyball46/keymaps/develop/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball46/keymaps/develop/keymap.c
@@ -46,6 +46,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 void oledkit_render_info_user(void) {
     keyball_oled_render_keyinfo();
     keyball_oled_render_ballinfo();
+    keyball_oled_render_layerinfo();
 }
 #endif
 

--- a/qmk_firmware/keyboards/keyball/keyball46/keymaps/test/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball46/keymaps/test/keymap.c
@@ -51,5 +51,6 @@ void keyboard_post_init_user() {
 void oledkit_render_info_user(void) {
     keyball_oled_render_keyinfo();
     keyball_oled_render_ballinfo();
+    keyball_oled_render_layerinfo();
 }
 #endif

--- a/qmk_firmware/keyboards/keyball/keyball46/keymaps/test_Both/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball46/keymaps/test_Both/keymap.c
@@ -52,5 +52,6 @@ void keyboard_post_init_user() {
 void oledkit_render_info_user(void) {
     keyball_oled_render_keyinfo();
     keyball_oled_render_ballinfo();
+    keyball_oled_render_layerinfo();
 }
 #endif

--- a/qmk_firmware/keyboards/keyball/keyball46/keymaps/test_Left/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball46/keymaps/test_Left/keymap.c
@@ -52,5 +52,6 @@ void keyboard_post_init_user() {
 void oledkit_render_info_user(void) {
     keyball_oled_render_keyinfo();
     keyball_oled_render_ballinfo();
+    keyball_oled_render_layerinfo();
 }
 #endif

--- a/qmk_firmware/keyboards/keyball/keyball46/keymaps/via/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball46/keymaps/via/keymap.c
@@ -112,26 +112,6 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 void oledkit_render_info_user(void) {
     keyball_oled_render_keyinfo();
     keyball_oled_render_ballinfo();
-
-    const char *n;
-    switch (get_highest_layer(layer_state)) {
-        case _QWERTY:
-            n = PSTR("Default");
-            break;
-        case _RAISE:
-            n = PSTR("Raise");
-            break;
-        case _LOWER:
-            n = PSTR("Lower");
-            break;
-        case _BALL:
-            n = PSTR("Adjust");
-            break;
-        default:
-            n = PSTR("Undefined");
-            break;
-    }
-    oled_write_P(PSTR("Layer: "), false);
-    oled_write_ln_P(n, false);
+    keyball_oled_render_layerinfo();
 }
 #endif

--- a/qmk_firmware/keyboards/keyball/keyball46/keymaps/via_Both/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball46/keymaps/via_Both/keymap.c
@@ -112,26 +112,6 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 void oledkit_render_info_user(void) {
     keyball_oled_render_keyinfo();
     keyball_oled_render_ballinfo();
-
-    const char *n;
-    switch (get_highest_layer(layer_state)) {
-        case _QWERTY:
-            n = PSTR("Default");
-            break;
-        case _RAISE:
-            n = PSTR("Raise");
-            break;
-        case _LOWER:
-            n = PSTR("Lower");
-            break;
-        case _BALL:
-            n = PSTR("Adjust");
-            break;
-        default:
-            n = PSTR("Undefined");
-            break;
-    }
-    oled_write_P(PSTR("Layer: "), false);
-    oled_write_ln_P(n, false);
+    keyball_oled_render_layerinfo();
 }
 #endif

--- a/qmk_firmware/keyboards/keyball/keyball46/keymaps/via_Left/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball46/keymaps/via_Left/keymap.c
@@ -112,26 +112,6 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 void oledkit_render_info_user(void) {
     keyball_oled_render_keyinfo();
     keyball_oled_render_ballinfo();
-
-    const char *n;
-    switch (get_highest_layer(layer_state)) {
-        case _QWERTY:
-            n = PSTR("Default");
-            break;
-        case _RAISE:
-            n = PSTR("Raise");
-            break;
-        case _LOWER:
-            n = PSTR("Lower");
-            break;
-        case _BALL:
-            n = PSTR("Adjust");
-            break;
-        default:
-            n = PSTR("Undefined");
-            break;
-    }
-    oled_write_P(PSTR("Layer: "), false);
-    oled_write_ln_P(n, false);
+    keyball_oled_render_layerinfo();
 }
 #endif

--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/default/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/default/keymap.c
@@ -69,5 +69,6 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 void oledkit_render_info_user(void) {
     keyball_oled_render_keyinfo();
     keyball_oled_render_ballinfo();
+    keyball_oled_render_layerinfo();
 }
 #endif

--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/develop/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/develop/keymap.c
@@ -54,5 +54,6 @@ void keyboard_post_init_user(void) {
 void oledkit_render_info_user(void) {
     keyball_oled_render_keyinfo();
     keyball_oled_render_ballinfo();
+    keyball_oled_render_layerinfo();
 }
 #endif

--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/test/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/test/keymap.c
@@ -47,5 +47,6 @@ void keyboard_post_init_user() {
 void oledkit_render_info_user(void) {
     keyball_oled_render_keyinfo();
     keyball_oled_render_ballinfo();
+    keyball_oled_render_layerinfo();
 }
 #endif

--- a/qmk_firmware/keyboards/keyball/keyball61/keymaps/via/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball61/keymaps/via/keymap.c
@@ -69,5 +69,6 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 void oledkit_render_info_user(void) {
     keyball_oled_render_keyinfo();
     keyball_oled_render_ballinfo();
+    keyball_oled_render_layerinfo();
 }
 #endif

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
@@ -409,6 +409,28 @@ void keyball_oled_render_keyinfo(void) {
 #endif
 }
 
+void keyball_oled_render_layerinfo(void) {
+#ifdef OLED_ENABLE
+    // Format: `Layer: {layer}`
+    //
+    // Output example:
+    //
+    //     Layer: 0
+    //
+    oled_write_P(PSTR("Layer: "), false);
+    layer_state_t layer = layer_state;
+    for (uint8_t i = 0; i < 8; i++) {
+        if (layer & 1) {
+            oled_write_char('#', false);
+        } else {
+            oled_write_char('-', false);
+        }
+        layer >>= 1;
+    }
+    oled_advance_page(true);
+#endif
+}
+
 //////////////////////////////////////////////////////////////////////////////
 // Public API functions
 

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
@@ -411,23 +411,16 @@ void keyball_oled_render_keyinfo(void) {
 
 void keyball_oled_render_layerinfo(void) {
 #ifdef OLED_ENABLE
-    // Format: `Layer: {layer}`
+    // Format: `Layer:{layer state}`
     //
     // Output example:
     //
-    //     Layer: 0
+    //     Layer:-23------------
     //
-    oled_write_P(PSTR("Layer: "), false);
-    layer_state_t layer = layer_state;
-    for (uint8_t i = 0; i < 8; i++) {
-        if (layer & 1) {
-            oled_write_char('0' + i, false);
-        } else {
-            oled_write_char('-', false);
-        }
-        layer >>= 1;
+    oled_write_P(PSTR("Layer:"), false);
+    for (uint8_t i = 1; i < 16; i++) {
+        oled_write_char((layer_state_is(i) ? to_1x(i) : '_'), false);
     }
-    oled_advance_page(true);
 #endif
 }
 

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
@@ -421,7 +421,7 @@ void keyball_oled_render_layerinfo(void) {
     layer_state_t layer = layer_state;
     for (uint8_t i = 0; i < 8; i++) {
         if (layer & 1) {
-            oled_write_char('#', false);
+            oled_write_char('0' + i, false);
         } else {
             oled_write_char('-', false);
         }

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
@@ -154,8 +154,9 @@ void keyball_oled_render_ballinfo(void);
 /// It shows column, row, key code, and key name (if available).
 void keyball_oled_render_keyinfo(void);
 
-/// keyball_oled_render_layerinfo renders current layer information to OLED.
-/// It shows layer mask with '#' for active layers and '-' for inactive layers.
+/// keyball_oled_render_layerinfo renders current layer status information to
+/// OLED.  It shows layer mask with number (1~f) for active layers and '_' for
+/// inactive layers.
 void keyball_oled_render_layerinfo(void);
 
 /// keyball_get_scroll_mode gets current scroll mode.

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
@@ -154,6 +154,10 @@ void keyball_oled_render_ballinfo(void);
 /// It shows column, row, key code, and key name (if available).
 void keyball_oled_render_keyinfo(void);
 
+/// keyball_oled_render_layerinfo renders current layer information to OLED.
+/// It shows layer mask with '#' for active layers and '-' for inactive layers.
+void keyball_oled_render_layerinfo(void);
+
 /// keyball_get_scroll_mode gets current scroll mode.
 bool keyball_get_scroll_mode(void);
 

--- a/qmk_firmware/keyboards/keyball/one47/keymaps/default/keymap.c
+++ b/qmk_firmware/keyboards/keyball/one47/keymaps/default/keymap.c
@@ -65,5 +65,6 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 void oledkit_render_info_user(void) {
     keyball_oled_render_keyinfo();
     keyball_oled_render_ballinfo();
+    keyball_oled_render_layerinfo();
 }
 #endif

--- a/qmk_firmware/keyboards/keyball/one47/keymaps/develop/keymap.c
+++ b/qmk_firmware/keyboards/keyball/one47/keymaps/develop/keymap.c
@@ -52,5 +52,6 @@ void keyboard_post_init_user(void) {
 void oledkit_render_info_user(void) {
     keyball_oled_render_keyinfo();
     keyball_oled_render_ballinfo();
+    keyball_oled_render_layerinfo();
 }
 #endif

--- a/qmk_firmware/keyboards/keyball/one47/keymaps/test/keymap.c
+++ b/qmk_firmware/keyboards/keyball/one47/keymaps/test/keymap.c
@@ -46,5 +46,6 @@ void keyboard_post_init_user() {
 void oledkit_render_info_user(void) {
     keyball_oled_render_keyinfo();
     keyball_oled_render_ballinfo();
+    keyball_oled_render_layerinfo();
 }
 #endif

--- a/qmk_firmware/keyboards/keyball/one47/keymaps/via/keymap.c
+++ b/qmk_firmware/keyboards/keyball/one47/keymaps/via/keymap.c
@@ -65,5 +65,6 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 void oledkit_render_info_user(void) {
     keyball_oled_render_keyinfo();
     keyball_oled_render_ballinfo();
+    keyball_oled_render_layerinfo();
 }
 #endif


### PR DESCRIPTION
based on #203.

* use `layer_state_is()` to get each layer status
* check layer 1~15 (`1` ~ `f`)
* excluded layer 0, it is enabled always but layer state is not.
* use `_` to show "inactivated layer" instead of `-`
* show layer information below ball information