### PR TITLE
Print (up to 3) pressing keys on OLED

### DIFF
--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
@@ -416,6 +416,7 @@ void keyball_oled_render_keyinfo(void) {
     // then, writes pressing keys
     for (int i=0; i<KEYBALL_OLED_MAX_PRESSING_KEYCODES; i++) {
         if (keyball.pressing_kc[i]) {
+            // safety: if only 4 <= key < 57 keycodes are saved
             char name = pgm_read_byte(code_to_name + keyball.pressing_kc[i] - 4);
             oled_write_char(name, false);
         }
@@ -524,6 +525,7 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
         // stores the pressed key if the slot is vacant
         if (record->event.pressed && keyball.pressing_kc[i] == 0) {
             // store only valid keycodes
+            // This simplifies the code for OLED printing.
             if (lower_keycode >= 4 && lower_keycode < 57) {
                 keyball.pressing_kc[i] = lower_keycode;
             }

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
@@ -525,7 +525,7 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
         if (record->event.pressed && keyball.pressing_kc[i] == 0) {
             // store only valid keycodes
             if (lower_keycode >= 4 && lower_keycode < 57) {
-                keyball.pressing_kc[i] = keycode;
+                keyball.pressing_kc[i] = lower_keycode;
             }
             // no need to check other slots in either case above
             break;

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
@@ -407,10 +407,10 @@ void keyball_oled_render_keyinfo(void) {
         oled_write_P(PSTR("     "), false);
     }
     // pads spaces to align pressing keys to the right
-    oled_write_P(PSTR(" "), false);
+    oled_write_char(' ', false);
     for (int i=0; i<KEYBALL_OLED_MAX_PRESSING_KEYCODES; i++) {
         if (keyball.pressing_kc[i] == 0) {
-            oled_write_P(PSTR(" "), false);
+            oled_write_char(' ', false);
         }
     }
     // then, writes pressing keys

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
@@ -67,6 +67,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define KEYBALL_MODEL 44
 #endif
 
+#define KEYBALL_OLED_MAX_PRESSING_KEYCODES 3
+
 //////////////////////////////////////////////////////////////////////////////
 // Types
 
@@ -130,6 +132,9 @@ typedef struct {
     uint16_t       last_kc;
     keypos_t       last_pos;
     report_mouse_t last_mouse;
+
+    // It needs only the lower 8 bits of each key code to show on OLED.
+    uint8_t pressing_kc[KEYBALL_OLED_MAX_PRESSING_KEYCODES];
 } keyball_t;
 
 typedef enum {


### PR DESCRIPTION
It replaces the last section of the "Key" row on OLED with printing currently pressing (aka. not released) keys up to 3 keys. It shows the key state reactively. This kind of reactivity would allow us to easily diagnose misfunctioned behavior.
The reason I chose the section for placing this is that, ultimately, it does not provide additional information than the keycode section.
A huge downside is that it increases the firmware size as 128 bytes (in my build environment).

`27628/28672 (96%, 1044 bytes free)` 
to
`27756/28672 (96%, 916 bytes free)`

https://github.com/Yowkees/keyball/assets/8780513/f118a390-f6e3-48f5-8b7d-9cfc16975d95