### PR TITLE
Fix asymmetric behavior of scroll direction

### DIFF
--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
@@ -160,9 +160,9 @@ static void motion_to_mouse_move(keyball_motion_t *m, report_mouse_t *r, bool is
 static void motion_to_mouse_scroll(keyball_motion_t *m, report_mouse_t *r, bool is_left) {
     // consume motion of trackball.
     uint8_t div = keyball_get_scroll_div() - 1;
-    int16_t x   = m->x >> div;
+    int16_t x   = m->x / (1 << div);
     m->x -= x << div;
-    int16_t y = m->y >> div;
+    int16_t y = m->y / (1 << div);
     m->y -= y << div;
 
     // apply to mouse report.


### PR DESCRIPTION
When the scroll div is sufficiently large, you'll see a weird asymmetric behavior of scrolling; when you scroll towards the positive direction, the actual scroll happens after some ball movement, but when you scroll towards the negative direction,  the scroll happens with a little ball movement.
This happens because the behavior of right shift `>> div` is not symmetric for positive and negative lhs. For example, `1 >> 3` is zero, but `-1 >> 3` is `-1`. https://wandbox.org/permlink/M943OJ3soMrS4uH6

This PR fixes the issue by use division `/ (1 << div)` instead, which truncates towards zero.