### PR TITLE
Disable minor features

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball39/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball39/config.h
@@ -31,10 +31,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define SOFT_SERIAL_PIN         D2
 #define SPLIT_HAND_MATRIX_GRID  F6, B5
 #define SPLIT_USB_DETECT
-#define SPLIT_USB_TIMEOUT       500
 #ifdef OLED_ENABLE
 #    define SPLIT_OLED_ENABLE
 #endif
+
+// If your PC does not recognize Keyball, try setting this macro. This macro
+// increases the firmware size by 200 bytes, so it is disabled by default, but
+// it has been reported to work well in such cases.
+//#define SPLIT_WATCHDOG_ENABLE
 
 #define SPLIT_TRANSACTION_IDS_KB KEYBALL_GET_INFO, KEYBALL_GET_MOTION, KEYBALL_SET_CPI
 

--- a/qmk_firmware/keyboards/keyball/keyball39/rules.mk
+++ b/qmk_firmware/keyboards/keyball/keyball39/rules.mk
@@ -45,4 +45,5 @@ SRC += lib/keyball/keyball.c
 
 # Disable other features to squeeze firmware size
 SPACE_CADET_ENABLE = no
+GRAVE_ESC_ENABLE = no
 MAGIC_ENABLE = no

--- a/qmk_firmware/keyboards/keyball/keyball44/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball44/config.h
@@ -31,10 +31,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define SOFT_SERIAL_PIN         D2
 #define SPLIT_HAND_MATRIX_GRID  F7, D4
 #define SPLIT_USB_DETECT
-#define SPLIT_USB_TIMEOUT       500
 #ifdef OLED_ENABLE
 #    define SPLIT_OLED_ENABLE
 #endif
+
+// If your PC does not recognize Keyball, try setting this macro. This macro
+// increases the firmware size by 200 bytes, so it is disabled by default, but
+// it has been reported to work well in such cases.
+//#define SPLIT_WATCHDOG_ENABLE
 
 #define SPLIT_TRANSACTION_IDS_KB KEYBALL_GET_INFO, KEYBALL_GET_MOTION, KEYBALL_SET_CPI
 

--- a/qmk_firmware/keyboards/keyball/keyball44/rules.mk
+++ b/qmk_firmware/keyboards/keyball/keyball44/rules.mk
@@ -16,7 +16,7 @@ NKRO_ENABLE = no            # Enable N-Key Rollover
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 AUDIO_ENABLE = no           # Audio output
 
-# Keyball39 is split keyboard.
+# Keyball44 is split keyboard.
 SPLIT_KEYBOARD = yes
 
 # Optical sensor driver for trackball.
@@ -45,4 +45,5 @@ SRC += lib/keyball/keyball.c
 
 # Disable other features to squeeze firmware size
 SPACE_CADET_ENABLE = no
+GRAVE_ESC_ENABLE = no
 MAGIC_ENABLE = no

--- a/qmk_firmware/keyboards/keyball/keyball46/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball46/config.h
@@ -32,10 +32,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define SPLIT_HAND_MATRIX_GRID F7, B5     // for ball
 //#define SPLIT_HAND_MATRIX_GRID F6, B5     // for noball
 #define SPLIT_USB_DETECT
-#define SPLIT_USB_TIMEOUT       500
 #ifdef OLED_ENABLE
 #    define SPLIT_OLED_ENABLE
 #endif
+
+// If your PC does not recognize Keyball, try setting this macro. This macro
+// increases the firmware size by 200 bytes, so it is disabled by default, but
+// it has been reported to work well in such cases.
+//#define SPLIT_WATCHDOG_ENABLE
 
 #define SPLIT_TRANSACTION_IDS_KB KEYBALL_GET_INFO, KEYBALL_GET_MOTION, KEYBALL_SET_CPI
 

--- a/qmk_firmware/keyboards/keyball/keyball46/rules.mk
+++ b/qmk_firmware/keyboards/keyball/keyball46/rules.mk
@@ -16,7 +16,6 @@ NKRO_ENABLE = no            # Enable N-Key Rollover
 BACKLIGHT_ENABLE = no       # Enable keyboard backlight functionality
 AUDIO_ENABLE = no           # Audio output
 
-
 # Keyball46 is split keyboard.
 SPLIT_KEYBOARD = yes
 
@@ -46,4 +45,5 @@ SRC += lib/keyball/keyball.c
 
 # Disable other features to squeeze firmware size
 SPACE_CADET_ENABLE = no
+GRAVE_ESC_ENABLE = no
 MAGIC_ENABLE = no

--- a/qmk_firmware/keyboards/keyball/keyball61/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball61/config.h
@@ -30,10 +30,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define SOFT_SERIAL_PIN         D2
 #define SPLIT_HAND_MATRIX_GRID  F7, D7
 #define SPLIT_USB_DETECT
-#define SPLIT_USB_TIMEOUT       500
 #ifdef OLED_ENABLE
 #    define SPLIT_OLED_ENABLE
 #endif
+
+// If your PC does not recognize Keyball, try setting this macro. This macro
+// increases the firmware size by 200 bytes, so it is disabled by default, but
+// it has been reported to work well in such cases.
+//#define SPLIT_WATCHDOG_ENABLE
 
 #define SPLIT_TRANSACTION_IDS_KB KEYBALL_GET_INFO, KEYBALL_GET_MOTION, KEYBALL_SET_CPI
 

--- a/qmk_firmware/keyboards/keyball/keyball61/rules.mk
+++ b/qmk_firmware/keyboards/keyball/keyball61/rules.mk
@@ -20,7 +20,7 @@ AUDIO_ENABLE = no           # Audio output
 CUSTOM_MATRIX = lite
 SRC += lib/duplexmatrix/duplexmatrix.c
 
-# Split keyboard.
+# Keyball61 is split keyboard.
 SPLIT_KEYBOARD = yes
 
 # Optical sensor driver for trackball.
@@ -49,4 +49,5 @@ SRC += lib/keyball/keyball.c
 
 # Disable other features to squeeze firmware size
 SPACE_CADET_ENABLE = no
+GRAVE_ESC_ENABLE = no
 MAGIC_ENABLE = no

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
@@ -696,3 +696,25 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
 
     return true;
 }
+
+// Disable functions keycode_config() and mod_config() in keycode_config.c to
+// reduce size.  These functions are provided for customizing magic keycode.
+// These two functions are mostly unnecessary if `MAGIC_KEYCODE_ENABLE = no` is
+// set.
+//
+// If `MAGIC_KEYCODE_ENABLE = no` and you want to keep these two functions as
+// they are, define the macro KEYBALL_KEEP_MAGIC_FUNCTIONS.
+//
+// See: https://docs.qmk.fm/#/squeezing_avr?id=magic-functions
+//
+#if !defined(MAGIC_KEYCODE_ENABLE) && !defined(KEYBALL_KEEP_MAGIC_FUNCTIONS)
+
+uint16_t keycode_config(uint16_t keycode) {
+    return keycode;
+}
+
+uint8_t mod_config(uint8_t mod) {
+    return mod;
+}
+
+#endif

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
@@ -55,6 +55,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define KEYBALL_PMW3360_UPLOAD_SROM_ID 0x04
 //#define KEYBALL_PMW3360_UPLOAD_SROM_ID 0x81
 
+/// Defining this macro keeps two functions intact: keycode_config() and
+/// mod_config() in keycode_config.c.
+///
+/// These functions customize the magic key code and are useless if the magic
+/// key code is disabled.  Therefore, Keyball automatically disables it.
+/// However, there may be cases where you still need these functions even after
+/// disabling the magic key code. In that case, define this macro.
+//#define KEYBALL_KEEP_MAGIC_FUNCTIONS
+
 //////////////////////////////////////////////////////////////////////////////
 // Constants
 

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keycodes.md
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keycodes.md
@@ -19,8 +19,8 @@
 | `SCRL_DVI` | `Kb 8`          | `0x7e08` | Increase scroll divider (max D7 = 1/128) <- Most Scroll slow      |
 | `SCRL_DVD` | `Kb 9`          | `0x7e09` | Decrease scroll divider (min 0 = 1/1) <- Most Scroll fast         |
 | `AML_TO`   | `Kb 10`         | `0x7e0a` | Toggle automatic mouse layer                                      |
-| `AML_I50`  | `Kb 11`         | `0x7e0b` | Increase 50ms automatic mouse layer timeout(max 15=950ms)         |
-| `AML_D50`  | `Kb 12`         | `0x7e0c` | Decrease 50ms automatic mouse layer timeout(min 1=250ms)          |
+| `AML_I50`  | `Kb 11`         | `0x7e0b` | Increase 50ms automatic mouse layer timeout (max 1000ms)          |
+| `AML_D50`  | `Kb 12`         | `0x7e0c` | Decrease 50ms automatic mouse layer timeout (min 100ms)           |
 
 [^1]: CPI, scroll divider, automatic mouse layer's enable/disable, and automatic mouse layer's timeout.
 
@@ -40,7 +40,7 @@
 | `SCRL_DVI` | `Kb 8`          | `0x7e08` | スクロール除数を１つ上げます(max D7 = 1/128)←最もスクロール遅い   |
 | `SCRL_DVD` | `Kb 9`          | `0x7e09` | スクロール除数を１つ下げます(min D0 = 1/1)←最もスクロール速い     |
 | `AML_TO`   | `Kb 10`         | `0x7e0a` | 自動マウスレイヤーをトグルします。                                |
-| `AML_I50`  | `Kb 11`         | `0x7e0b` | 自動マウスレイヤーのタイムアウトを50msec増やします(max 15=950ms)  |
-| `AML_D50`  | `Kb 12`         | `0x7e0c` | 自動マウスレイヤーのタイムアウトを50msec減らします(min 1=250ms)   |
+| `AML_I50`  | `Kb 11`         | `0x7e0b` | 自動マウスレイヤーのタイムアウトを50msec増やします (max 1000ms)   |
+| `AML_D50`  | `Kb 12`         | `0x7e0c` | 自動マウスレイヤーのタイムアウトを50msec減らします (min 100ms)    |
 
 [^2]: CPI、スクロール除数、自動マウスレイヤーのON/OFF状態、及び自動マウスレイヤのタイムアウト

--- a/qmk_firmware/keyboards/keyball/lib/oledkit/oledkit.c
+++ b/qmk_firmware/keyboards/keyball/lib/oledkit/oledkit.c
@@ -46,6 +46,15 @@ __attribute__((weak)) bool oled_task_user(void) {
 }
 
 __attribute__((weak)) oled_rotation_t oled_init_user(oled_rotation_t rotation) {
+    // Logo needs to be rotated 180 degrees.
+    //
+    // A typical OLED has a narrow margin on the left side near the origin, and
+    // a wide margin on the right side. The Keyball logo consists of three
+    // lines. If the logo is displayed on an OLED consisting of four lines, the
+    // margin on the right side will be too large and the balance is not good.
+    //
+    // Additionally, by rotating it, the left side of the logo will be above
+    // the OLED screen, giving it a natural look.
     return !is_keyboard_master() ? OLED_ROTATION_180 : rotation;
 }
 

--- a/qmk_firmware/keyboards/keyball/one47/rules.mk
+++ b/qmk_firmware/keyboards/keyball/one47/rules.mk
@@ -20,7 +20,7 @@ AUDIO_ENABLE = no           # Audio output
 CUSTOM_MATRIX = lite
 SRC += lib/duplexmatrix/duplexmatrix.c
 
-# Non-split keyboard.
+# One47 is non-split keyboard.
 SPLIT_KEYBOARD = no
 
 # Optical sensor driver for trackball.
@@ -49,4 +49,5 @@ SRC += lib/keyball/keyball.c
 
 # Disable other features to squeeze firmware size
 SPACE_CADET_ENABLE = no
+GRAVE_ESC_ENABLE = no
 MAGIC_ENABLE = no


### PR DESCRIPTION
Disabled features

* `GRAVE_ESC_ENABLE = no` (80 bytes)
* Magic functions (570 bytes)

Others:

* Remove `define SPLIT_USB_TIMEOUT 500`, therefore default `2000` msec is applied. This may help in some environments where Keyball is not recognized
* Fix description of keycodes