### PR TITLE
Configurable threshold to prevent tiny movements activating auto mouse layer

### DIFF
--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
@@ -277,6 +277,9 @@ report_mouse_t pointing_device_driver_get_report(report_mouse_t rep) {
     }
     // report mouse event, if keyboard is primary.
     if (is_keyboard_master() && should_report()) {
+        // Reset total motion tracker.
+        keyball.total_motion.x = 0;
+        keyball.total_motion.y = 0;
         // modify mouse report by PMW3360 motion.
         motion_to_mouse(&keyball.this_motion, &rep, is_keyboard_left(), keyball.scroll_mode);
         motion_to_mouse(&keyball.that_motion, &rep, !is_keyboard_left(), keyball.scroll_mode ^ keyball.this_have_ball);
@@ -284,6 +287,12 @@ report_mouse_t pointing_device_driver_get_report(report_mouse_t rep) {
         keyball.last_mouse = rep;
     }
     return rep;
+}
+
+bool auto_mouse_activation(report_mouse_t mouse_report) {
+    keyball.total_motion.x += mouse_report.x;
+    keyball.total_motion.y += mouse_report.y;
+    return abs(keyball.total_motion.x) > KEYBALL_AUTO_MOUSE_THRESHOLD || abs(keyball.total_motion.y) > KEYBALL_AUTO_MOUSE_THRESHOLD || mouse_report.buttons;
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
@@ -51,7 +51,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /// Threshold of mouse movement before layer change occurs
 #ifndef KEYBALL_AUTO_MOUSE_THRESHOLD
-#    define KEYBALL_AUTO_MOUSE_THRESHOLD 5
+#    define KEYBALL_AUTO_MOUSE_THRESHOLD 2
 #endif
 
 /// Specify SROM ID to be uploaded PMW3360DW (optical sensor).  It will be

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
@@ -49,6 +49,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #    define KEYBALL_SCROLLSNAP_TENSION_THRESHOLD 12
 #endif
 
+/// Threshold of mouse movement before layer change occurs
+#ifndef KEYBALL_AUTO_MOUSE_THRESHOLD
+#    define KEYBALL_AUTO_MOUSE_THRESHOLD 5
+#endif
+
 /// Specify SROM ID to be uploaded PMW3360DW (optical sensor).  It will be
 /// enabled high CPI setting or so.  Valid valus are 0x04 or 0x81.  Define this
 /// in your config.h to be enable.  Please note that using this option will
@@ -158,6 +163,7 @@ typedef struct {
 
     keyball_motion_t this_motion;
     keyball_motion_t that_motion;
+    keyball_motion_t total_motion;
 
     uint8_t cpi_value;
     bool    cpi_changed;


### PR DESCRIPTION
Hello,

Thank you for efforts supporting this great device.  I have been enjoying the feature added in https://github.com/Yowkees/keyball/pull/508 and noticed that sometimes tiny movements, especially typing quickly, were accidentally activating the mouse layer.

I noticed that the qmk firmware mainline had a setting for this, detailed here https://github.com/qmk/qmk_firmware/pull/21398 and added in version 0.24.0.   Based on the code there, I tried implementing it myself in our keyball fork.

I am not sure about a good starting value though.   