### PR TITLE
Dev hold&tap

### DIFF
--- a/BuildMemo.txt
+++ b/BuildMemo.txt
@@ -21,7 +21,8 @@ $ qmk flash -kb keyball/keyball44 -km my_keymap
 
 # やったことメモ
 
-1. AutoMouseLayerを1から2に変更
+1. -AutoMouseLayerを1から2に変更-
+   →AutoMouseLayerを1に戻してRemapでLayer1と2のキーマップをごっそり入れ替えた
 2. トラックボール加速機能実装
    以下を参考にした。
    https://x.com/mass_0X00/status/1824373363604853180

--- a/BuildMemo.txt
+++ b/BuildMemo.txt
@@ -1,0 +1,29 @@
+
+# ビルドとProMicroへのflash手順
+
+(*) QMK_MSYSのセットアップについては省略
+
+1. keyballのリポジトリクローン
+$ git clone https://github.com/suijinn/keyball.git keyball
+
+
+2. qmk_firmwareのリポジトリクローン
+   対応しているバージョンに注意
+$ git clone https://github.com/qmk/qmk_firmware.git --depth 1 --recurse-submodules --shallow-submodules -b 0.22.14 qmk
+
+3. keyball→qmkへのシンボリックリンクを貼る
+mklink /D %USERPROFILE%\qmk\keyboards\keyball %USERPROFILE%\keyball\qmk_firmware\keyboards\keyball
+
+4. 編集する。keymapはkeyball44/my_keymap/以下を使う。
+
+5. ビルド&flash
+$ qmk flash -kb keyball/keyball44 -km my_keymap
+
+-----
+
+# 参考
+
+* keyball qmkのReadme
+  https://github.com/Yowkees/keyball/blob/main/qmk_firmware/keyboards/keyball/readme.md
+* 環境構築
+  https://note.com/yinouet1001/n/n54e6d3dc243a

--- a/BuildMemo.txt
+++ b/BuildMemo.txt
@@ -19,7 +19,16 @@ mklink /D %USERPROFILE%\qmk\keyboards\keyball %USERPROFILE%\keyball\qmk_firmware
 5. ビルド&flash
 $ qmk flash -kb keyball/keyball44 -km my_keymap
 
------
+# やったことメモ
+
+1. AutoMouseLayerを1から2に変更
+2. トラックボール加速機能実装
+   以下を参考にした。
+   https://x.com/mass_0X00/status/1824373363604853180
+3. マウスキーを押すまでAutoMouseLayerに留まる
+   以下を参考にした。
+   https://github.com/negokaz/keyball/pull/2
+
 
 # 参考
 

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/my_keymap/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/my_keymap/config.h
@@ -1,0 +1,39 @@
+/*
+This is the c configuration file for the keymap
+
+Copyright 2022 @Yowkees
+Copyright 2022 MURAOKA Taro (aka KoRoN, @kaoriya)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#ifdef RGBLIGHT_ENABLE
+//#    define RGBLIGHT_EFFECT_BREATHING
+//#    define RGBLIGHT_EFFECT_RAINBOW_MOOD
+//#    define RGBLIGHT_EFFECT_RAINBOW_SWIRL
+//#    define RGBLIGHT_EFFECT_SNAKE
+//#    define RGBLIGHT_EFFECT_KNIGHT
+//#    define RGBLIGHT_EFFECT_CHRISTMAS
+#    define RGBLIGHT_EFFECT_STATIC_GRADIENT
+//#    define RGBLIGHT_EFFECT_RGB_TEST
+//#    define RGBLIGHT_EFFECT_ALTERNATING
+//#    define RGBLIGHT_EFFECT_TWINKLE
+#endif
+
+#define TAP_CODE_DELAY 5
+
+#define POINTING_DEVICE_AUTO_MOUSE_ENABLE
+#define AUTO_MOUSE_DEFAULT_LAYER 1

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/my_keymap/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/my_keymap/config.h
@@ -37,3 +37,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define POINTING_DEVICE_AUTO_MOUSE_ENABLE
 #define AUTO_MOUSE_DEFAULT_LAYER 2
+#define AUTO_MOUSE_LAYER_KEEP_TIME 30000

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/my_keymap/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/my_keymap/config.h
@@ -36,4 +36,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define TAP_CODE_DELAY 5
 
 #define POINTING_DEVICE_AUTO_MOUSE_ENABLE
-#define AUTO_MOUSE_DEFAULT_LAYER 1
+#define AUTO_MOUSE_DEFAULT_LAYER 2

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/my_keymap/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/my_keymap/config.h
@@ -38,3 +38,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define POINTING_DEVICE_AUTO_MOUSE_ENABLE
 #define AUTO_MOUSE_DEFAULT_LAYER 1
 #define AUTO_MOUSE_LAYER_KEEP_TIME 30000
+
+#define PERMISSIVE_HOLD
+#define RETRO_TAPPING

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/my_keymap/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/my_keymap/config.h
@@ -36,5 +36,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define TAP_CODE_DELAY 5
 
 #define POINTING_DEVICE_AUTO_MOUSE_ENABLE
-#define AUTO_MOUSE_DEFAULT_LAYER 2
+#define AUTO_MOUSE_DEFAULT_LAYER 1
 #define AUTO_MOUSE_LAYER_KEEP_TIME 30000

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/my_keymap/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/my_keymap/config.h
@@ -40,4 +40,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define AUTO_MOUSE_LAYER_KEEP_TIME 30000
 
 #define PERMISSIVE_HOLD
-#define RETRO_TAPPING
+#define TAPPING_TERM 300

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/my_keymap/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/my_keymap/keymap.c
@@ -1,0 +1,71 @@
+/*
+Copyright 2022 @Yowkees
+Copyright 2022 MURAOKA Taro (aka KoRoN, @kaoriya)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include QMK_KEYBOARD_H
+
+#include "quantum.h"
+
+// clang-format off
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+  // keymap for default (VIA)
+  [0] = LAYOUT_universal(
+    KC_ESC   , KC_Q     , KC_W     , KC_E     , KC_R     , KC_T     ,                                        KC_Y     , KC_U     , KC_I     , KC_O     , KC_P     , KC_DEL   ,
+    KC_TAB   , KC_A     , KC_S     , KC_D     , KC_F     , KC_G     ,                                        KC_H     , KC_J     , KC_K     , KC_L     , KC_SCLN  , S(KC_7)  ,
+    KC_LSFT  , KC_Z     , KC_X     , KC_C     , KC_V     , KC_B     ,                                        KC_N     , KC_M     , KC_COMM  , KC_DOT   , KC_SLSH  , KC_INT1  ,
+              KC_LALT,KC_LGUI,LCTL_T(KC_LNG2)     ,LT(1,KC_SPC),LT(3,KC_LNG1),                  KC_BSPC,LT(2,KC_ENT), RCTL_T(KC_LNG2),     KC_RALT  , KC_PSCR
+  ),
+
+  [1] = LAYOUT_universal(
+    SSNP_FRE ,  KC_F1   , KC_F2    , KC_F3   , KC_F4    , KC_F5    ,                                         KC_F6    , KC_F7    , KC_F8    , KC_F9    , KC_F10   , KC_F11   ,
+    SSNP_VRT ,  _______ , _______  , KC_UP   , KC_ENT   , KC_DEL   ,                                         KC_PGUP  , KC_BTN1  , KC_UP    , KC_BTN2  , KC_BTN3  , KC_F12   ,
+    SSNP_HOR ,  _______ , KC_LEFT  , KC_DOWN , KC_RGHT  , KC_BSPC  ,                                         KC_PGDN  , KC_LEFT  , KC_DOWN  , KC_RGHT  , _______  , _______  ,
+                  _______  , _______ , _______  ,         _______  , _______  ,                   _______  , _______  , _______       , _______  , _______
+  ),
+
+  [2] = LAYOUT_universal(
+    _______  ,S(KC_QUOT), KC_7     , KC_8    , KC_9     , S(KC_8)  ,                                         S(KC_9)  , S(KC_1)  , S(KC_6)  , KC_LBRC  , S(KC_4)  , _______  ,
+    _______  ,S(KC_SCLN), KC_4     , KC_5    , KC_6     , KC_RBRC  ,                                         KC_NUHS  , KC_MINS  , S(KC_EQL), S(KC_3)  , KC_QUOT  , S(KC_2)  ,
+    _______  ,S(KC_MINS), KC_1     , KC_2    , KC_3     ,S(KC_RBRC),                                        S(KC_NUHS),S(KC_INT1), KC_EQL   ,S(KC_LBRC),S(KC_SLSH),S(KC_INT3),
+                  KC_0     , KC_DOT  , _______  ,         _______  , _______  ,                   KC_DEL   , _______  , _______       , _______  , _______
+  ),
+
+  [3] = LAYOUT_universal(
+    RGB_TOG  , AML_TO   , AML_I50  , AML_D50  , _______  , _______  ,                                        RGB_M_P  , RGB_M_B  , RGB_M_R  , RGB_M_SW , RGB_M_SN , RGB_M_K  ,
+    RGB_MOD  , RGB_HUI  , RGB_SAI  , RGB_VAI  , _______  , SCRL_DVI ,                                        RGB_M_X  , RGB_M_G  , RGB_M_T  , RGB_M_TW , _______  , _______  ,
+    RGB_RMOD , RGB_HUD  , RGB_SAD  , RGB_VAD  , _______  , SCRL_DVD ,                                        CPI_D1K  , CPI_D100 , CPI_I100 , CPI_I1K  , _______  , KBC_SAVE ,
+                  QK_BOOT  , KBC_RST  , _______  ,        _______  , _______  ,                   _______  , _______  , _______       , KBC_RST  , QK_BOOT
+  ),
+};
+// clang-format on
+
+layer_state_t layer_state_set_user(layer_state_t state) {
+    // Auto enable scroll mode when the highest layer is 3
+    keyball_set_scroll_mode(get_highest_layer(state) == 3);
+    return state;
+}
+
+#ifdef OLED_ENABLE
+
+#    include "lib/oledkit/oledkit.h"
+
+void oledkit_render_info_user(void) {
+    keyball_oled_render_keyinfo();
+    keyball_oled_render_ballinfo();
+    keyball_oled_render_layerinfo();
+}
+#endif

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/my_keymap/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/my_keymap/keymap.c
@@ -56,6 +56,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 layer_state_t layer_state_set_user(layer_state_t state) {
     // Auto enable scroll mode when the highest layer is 3
     keyball_set_scroll_mode(get_highest_layer(state) == 3);
+#ifdef POINTING_DEVICE_AUTO_MOUSE_ENABLE
+    keyball_handle_auto_mouse_layer_change(state);
+#endif
     return state;
 }
 

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/my_keymap/rules.mk
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/my_keymap/rules.mk
@@ -1,0 +1,5 @@
+RGBLIGHT_ENABLE = yes
+
+OLED_ENABLE = yes
+
+VIA_ENABLE = yes

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
@@ -235,7 +235,38 @@ __attribute__((weak)) void keyball_on_apply_motion_to_mouse_scroll(keyball_motio
 #endif
 }
 
+// --------------------------------------------------
+// from X
+// https://x.com/mass_0X00/status/1824373363604853180
+// --------------------------------------------------
+static void adjust_mouse_speed(keyball_motion_t *m) {
+    int16_t movement_size = abs(m->x) + abs(m->y);
+
+    float speed_multiplier = 1.0;
+    if (movement_size > 60) {
+        speed_multiplier = 3.0;
+    } else if (movement_size > 30) {
+        speed_multiplier = 1.5;
+    } else if (movement_size > 5) {
+        speed_multiplier = 1.0;
+    } else if (movement_size > 4) {
+        speed_multiplier = 0.9;
+    } else if (movement_size > 3) {
+        speed_multiplier = 0.7;
+    } else if (movement_size > 2) {
+        speed_multiplier = 0.5;
+    } else if (movement_size > 1) {
+        speed_multiplier = 0.2;
+    } else {
+        // NOP
+    }
+
+    m->x = clip2int8((int16_t)(m->x * speed_multiplier));
+    m->y = clip2int8((int16_t)(m->y * speed_multiplier));
+}
+
 static void motion_to_mouse(keyball_motion_t *m, report_mouse_t *r, bool is_left, bool as_scroll) {
+    adjust_mouse_speed(m);
     if (as_scroll) {
         keyball_on_apply_motion_to_mouse_scroll(m, r, is_left);
     } else {

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
@@ -266,10 +266,10 @@ static void adjust_mouse_speed(keyball_motion_t *m) {
 }
 
 static void motion_to_mouse(keyball_motion_t *m, report_mouse_t *r, bool is_left, bool as_scroll) {
-    adjust_mouse_speed(m);
     if (as_scroll) {
         keyball_on_apply_motion_to_mouse_scroll(m, r, is_left);
     } else {
+        adjust_mouse_speed(m);
         keyball_on_apply_motion_to_mouse_move(m, r, is_left);
     }
 }

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
@@ -32,6 +32,7 @@ const uint8_t SCROLL_DIV_MAX = 7;
 const uint16_t AML_TIMEOUT_MIN = 100;
 const uint16_t AML_TIMEOUT_MAX = 1000;
 const uint16_t AML_TIMEOUT_QU  = 50;   // Quantization Unit
+const uint16_t AML_ACTIVATE_THRESHOLD = 50;
 
 static const char BL = '\xB0'; // Blank indicator character
 static const char LFSTR_ON[] PROGMEM = "\xB2\xB3";
@@ -50,6 +51,9 @@ keyball_t keyball = {
 
     .scroll_mode = false,
     .scroll_div  = 0,
+
+    .last_layer_state = 0,
+    .total_mouse_movement = 0,
 
     .pressing_keys = { BL, BL, BL, BL, BL, BL, 0 },
 };
@@ -295,6 +299,45 @@ static inline bool should_report(void) {
     return true;
 }
 
+#ifdef POINTING_DEVICE_AUTO_MOUSE_ENABLE
+static uint16_t keyball_get_auto_mouse_timeout(void) {
+    return keyball.auto_mouse_layer_timeout;
+}
+
+static void keyball_set_auto_mouse_timeout(uint16_t timeout) {
+    keyball.auto_mouse_layer_timeout = timeout;
+}
+
+static uint16_t get_auto_mouse_keep_time(void) {
+#ifdef AUTO_MOUSE_LAYER_KEEP_TIME
+        return AUTO_MOUSE_LAYER_KEEP_TIME;
+#else
+        return keyball_get_auto_mouse_timeout();
+#endif
+}
+
+static uint16_t movement_size_of(report_mouse_t *rep) {
+    return abs(rep->x) + abs(rep->y);
+}
+
+// override qmk function:
+//  https://github.com/qmk/qmk_firmware/blob/0.22.14/quantum/pointing_device/pointing_device_auto_mouse.c#L208-L221
+// activate auto mouse layer when mouse movement exceeds the threshold.
+bool auto_mouse_activation(report_mouse_t mouse_report) {
+    keyball.total_mouse_movement += movement_size_of(&mouse_report);
+    if (AML_ACTIVATE_THRESHOLD < keyball.total_mouse_movement) {
+        keyball.total_mouse_movement = 0;
+        if (get_auto_mouse_timeout() != get_auto_mouse_keep_time()) {
+            // keep AML if mouse is moving with "short timeout".
+            set_auto_mouse_timeout(get_auto_mouse_keep_time());
+        }
+        return true;
+    } else {
+        return mouse_report.buttons;
+    }
+}
+#endif
+
 report_mouse_t pointing_device_driver_get_report(report_mouse_t rep) {
     // fetch from optical sensor.
     if (keyball.this_have_ball) {
@@ -534,7 +577,7 @@ void keyball_oled_render_layerinfo(void) {
         oled_write_P(LFSTR_OFF, false);
     }
 
-    oled_write(format_4d(get_auto_mouse_timeout() / 10) + 1, false);
+    oled_write(format_4d(keyball_get_auto_mouse_timeout() / 10) + 1, false);
     oled_write_char('0', false);
 #    else
     oled_write_P(PSTR("\xC2\xC3\xB4\xB5 ---"), false);
@@ -593,6 +636,21 @@ void keyball_set_cpi(uint8_t cpi) {
     }
 }
 
+#ifdef POINTING_DEVICE_AUTO_MOUSE_ENABLE
+void keyball_handle_auto_mouse_layer_change(layer_state_t state) {
+    layer_state_t last_state = keyball.last_layer_state;
+    // go into AML
+    if (!layer_state_cmp(last_state, AUTO_MOUSE_DEFAULT_LAYER) && layer_state_cmp(state, AUTO_MOUSE_DEFAULT_LAYER)) {
+        keyball.total_mouse_movement = 0;
+    } // go out AML
+    else if (layer_state_cmp(last_state, AUTO_MOUSE_DEFAULT_LAYER) && !layer_state_cmp(state, AUTO_MOUSE_DEFAULT_LAYER)) {
+        set_auto_mouse_timeout(get_auto_mouse_keep_time());
+        keyball.total_mouse_movement = 0;
+    }
+    keyball.last_layer_state = state;
+}
+#endif
+
 //////////////////////////////////////////////////////////////////////////////
 // Keyboard hooks
 
@@ -613,7 +671,7 @@ void keyboard_post_init_kb(void) {
         keyball_set_scroll_div(c.sdiv);
 #ifdef POINTING_DEVICE_AUTO_MOUSE_ENABLE
         set_auto_mouse_enable(c.amle);
-        set_auto_mouse_timeout(c.amlto == 0 ? AUTO_MOUSE_TIME : (c.amlto + 1) * AML_TIMEOUT_QU);
+        keyball_set_auto_mouse_timeout(c.amlto == 0 ? AUTO_MOUSE_TIME : (c.amlto + 1) * AML_TIMEOUT_QU);
 #endif
 #if KEYBALL_SCROLLSNAP_ENABLE == 2
         keyball_set_scrollsnap_mode(c.ssnap);
@@ -682,6 +740,14 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
         keycode &= 0xff;
     }
 
+#ifdef POINTING_DEVICE_AUTO_MOUSE_ENABLE
+    // reduce auto mouse timeout if mouse key is pressed.
+    if ((is_mouse_record_kb(keycode, record) || IS_MOUSEKEY(keycode)) && record->event.pressed) {
+        set_auto_mouse_timeout(keyball_get_auto_mouse_timeout());
+        keyball.total_mouse_movement = 0;
+    }
+#endif
+
     switch (keycode) {
 #ifndef MOUSEKEY_ENABLE
         // process KC_MS_BTN1~8 by myself
@@ -718,7 +784,7 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
                     .sdiv  = keyball.scroll_div,
 #ifdef POINTING_DEVICE_AUTO_MOUSE_ENABLE
                     .amle  = get_auto_mouse_enable(),
-                    .amlto = (get_auto_mouse_timeout() / AML_TIMEOUT_QU) - 1,
+                    .amlto = (keyball_get_auto_mouse_timeout() / AML_TIMEOUT_QU) - 1,
 #endif
 #if KEYBALL_SCROLLSNAP_ENABLE == 2
                     .ssnap = keyball_get_scrollsnap_mode(),
@@ -768,14 +834,14 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
                 break;
             case AML_I50:
                 {
-                    uint16_t v = get_auto_mouse_timeout() + 50;
-                    set_auto_mouse_timeout(MIN(v, AML_TIMEOUT_MAX));
+                    uint16_t v = keyball_get_auto_mouse_timeout() + 50;
+                    keyball_set_auto_mouse_timeout(MIN(v, AML_TIMEOUT_MAX));
                 }
                 break;
             case AML_D50:
                 {
-                    uint16_t v = get_auto_mouse_timeout() - 50;
-                    set_auto_mouse_timeout(MAX(v, AML_TIMEOUT_MIN));
+                    uint16_t v = keyball_get_auto_mouse_timeout() - 50;
+                    keyball_set_auto_mouse_timeout(MAX(v, AML_TIMEOUT_MIN));
                 }
                 break;
 #endif

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
@@ -177,6 +177,10 @@ typedef struct {
     keypos_t       last_pos;
     report_mouse_t last_mouse;
 
+    uint16_t auto_mouse_layer_timeout;
+    layer_state_t last_layer_state;
+    uint16_t total_mouse_movement;
+
     // Buffer to indicate pressing keys.
     char pressing_keys[KEYBALL_OLED_MAX_PRESSING_KEYCODES + 1];
 } keyball_t;
@@ -270,3 +274,7 @@ uint8_t keyball_get_cpi(void);
 /// In addition, if you do not upload SROM, the maximum value will be limited
 /// to 34 (3500CPI).
 void keyball_set_cpi(uint8_t cpi);
+
+#ifdef POINTING_DEVICE_AUTO_MOUSE_ENABLE
+void keyball_handle_auto_mouse_layer_change(layer_state_t state);
+#endif


### PR DESCRIPTION
・PERMISSIVE_HOLDを設定
ホールドキー押下中に別キーを押した場合、押下時間に関係なくホールド判定にする。
・TAPPING_TERMを300に設定
PERMISSIVE_HOLDを設定しているのでTAPPING_TERMを長めの300に変更。

[参考]
・https://x.com/keyashantung/status/1826274837779894749
・https://golden-lucky.hatenablog.com/entry/2021/03/06/182958#PERMISSIVE_HOLD%E3%81%AF%E6%A1%88%E5%A4%96%E3%81%A8%E4%BD%BF%E3%81%88%E3%81%AA%E3%81%84
