### PR TITLE
fix firmware link keyball 44

### DIFF
--- a/keyball44/doc/rev1/buildguide_en.md
+++ b/keyball44/doc/rev1/buildguide_en.md
@@ -623,7 +623,7 @@ Now let's write the official firmware to ProMicro as the final step.
 
 Keyball44 is compatible with [ReMAP](https://remap-keys.app/configure), so firmware writing and keymap changes are possible without installing special software. For instructions on using Remap, please refer to the article by [Salicylic Acid's Self-Key Onsen Guide](https://salicylic-acid3.hatenablog.com/entry/remap-manual) for detailed information.  
 
-To use ReMAP, open the [REMAP catalog Keyball44 firmware page](https://remap-keys.app/catalog/k895xiCpsM5zlYZCPTEN/firmware) and FLASH (write) the Keyball44_via firmware.
+To use ReMAP, open the [REMAP catalog Keyball44 firmware page](https://remap-keys.app/catalog/tAJ9Htme4oNabUkx4832/firmware) and FLASH (write) the Keyball44_via firmware.
 
 
 

--- a/keyball44/doc/rev1/buildguide_jp.md
+++ b/keyball44/doc/rev1/buildguide_jp.md
@@ -624,7 +624,7 @@ M1.7のタッピングネジを付けます。
 
 Keyball44は[ReMAP](https://remap-keys.app/configure)に対応していますので特別なソフトをインストールしなくてもファームウェアの書き込みとキーマップの変更が可能です。Remapの使用方法については[自キ温泉ガイドのサリチル酸](https://salicylic-acid3.hatenablog.com/entry/remap-manual)の記事に詳しく掲載されています。  
 
-ReMAPを使用するために[REMAPカタログのKeyball44ファームウェアページ](https://remap-keys.app/catalog/k895xiCpsM5zlYZCPTEN/firmware)を開き、Keyball44_viaのファームウェアをFLASH（書き込み）してください。
+ReMAPを使用するために[REMAPカタログのKeyball44ファームウェアページ](https://remap-keys.app/catalog/tAJ9Htme4oNabUkx4832/firmware)を開き、Keyball44_viaのファームウェアをFLASH（書き込み）してください。
 
 
 


### PR DESCRIPTION
The firmware link in the keyball44 build guide was pointing to the 39 firmware, so I fixed it.