### PR TITLE
Add optional RP2040 CE support for Keyball44

### DIFF
--- a/qmk_firmware/keyboards/keyball/drivers/pmw3360/pmw3360.c
+++ b/qmk_firmware/keyboards/keyball/drivers/pmw3360/pmw3360.c
@@ -23,8 +23,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "srom_0x81.c"
 
 #define PMW3360_SPI_MODE 3
-#define PMW3360_SPI_DIVISOR (F_CPU / PMW3360_CLOCKS)
 #define PMW3360_CLOCKS 2000000
+
+#ifndef PMW3360_SPI_DIVISOR
+#    ifdef __AVR__
+#        define PMW3360_SPI_DIVISOR (F_CPU / PMW3360_CLOCKS)
+#    else
+#        define PMW3360_SPI_DIVISOR 64
+#    endif
+#endif
 
 static bool motion_bursting = false;
 

--- a/qmk_firmware/keyboards/keyball/keyball44/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball44/config.h
@@ -42,6 +42,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define SPLIT_TRANSACTION_IDS_KB KEYBALL_GET_INFO, KEYBALL_GET_MOTION, KEYBALL_SET_CPI
 
+// RP2040 controller conversion needs the Pro Micro SPI pins used by the sensor.
+#ifdef MCU_RP
+#    define SPI_DRIVER SPID0
+#    define SPI_SCK_PIN B1
+#    define SPI_MOSI_PIN B2
+#    define SPI_MISO_PIN B3
+#    define SPLIT_HAND_MATRIX_GRID_LOW_IS_LEFT
+#endif
+
 // RGB LED settings
 #define WS2812_DI_PIN       D3
 #ifdef RGBLIGHT_ENABLE

--- a/qmk_firmware/keyboards/keyball/keyball44/readme.md
+++ b/qmk_firmware/keyboards/keyball/keyball44/readme.md
@@ -13,6 +13,10 @@ Make example for this keyboard (after setting up your build environment):
 
     make keyball/keyball44:default
 
+For RP2040 Community Edition controllers such as Sea-Picro EXT, build with QMK conversion:
+
+    make keyball/keyball44:default CONVERT_TO=rp2040_ce
+
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
 
 ## Special keycodes


### PR DESCRIPTION
Support optional building Keyball44 for RP2040 Community Edition controllers such as Sea-Picro EXT.

The RP2040 path is enabled only when building with CONVERT_TO=rp2040_ce.

Test: make SKIP_GIT=yes COLOR=false CONVERT_TO=rp2040_ce keyball/keyball44:default

## References

There's been a lot of interest in RP2040 support. Here I only patch the Keyball44 as that's the only one I have to test. Some references:

 * https://github.com/Yowkees/keyball/issues/572
 * https://github.com/idank/qmk_firmware/tree/dev-rp2040/keyboards/keyball
 * https://github.com/Yowkees/keyball/issues/440
 * https://docs.holykeebs.com/guides/keyboard/keyball/
 * https://github.com/yinouet/keyball39rp
 * https://github.com/katsuhidem/keyball_rp2040
 * https://github.com/yinouet/keyball39rp
 * https://github.com/yamaryu211/keyball_rp2040_vial



