### PR TITLE
ci: bump actions in local composite actions to Node 24 runtimes

### DIFF
--- a/.github/actions/checkout-qmk_firmware/action.yml
+++ b/.github/actions/checkout-qmk_firmware/action.yml
@@ -15,7 +15,7 @@ runs:
   steps:
 
   - name: Checkout qmk_firmware
-    uses: actions/checkout@v4
+    uses: actions/checkout@v6
     with:
       path: ${{ inputs.path }}
       repository: qmk/qmk_firmware

--- a/.github/actions/release-archive/action.yml
+++ b/.github/actions/release-archive/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
 
   - name: Download artifacts
-    uses: actions/download-artifact@v4
+    uses: actions/download-artifact@v8
     with:
       pattern: ${{ inputs.name }}-*-firmware
       merge-multiple: true


### PR DESCRIPTION
## Problem

Every build job currently emits this deprecation warning:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4

The workflows under `.github/workflows/` have already been moved to Node 24 runtimes, but the two local composite actions under `.github/actions/` were left behind on v4:

| file | action |
| --- | --- |
| `.github/actions/checkout-qmk_firmware/action.yml` | `actions/checkout@v4` |
| `.github/actions/release-archive/action.yml` | `actions/download-artifact@v4` |

## Why this was missed

Dependabot does not scan composite actions in subdirectories. With `directory: "/"` it only searches `.github/workflows` and a root-level `action.yml`, so no update PR is ever opened for these two files.

Concretely, 0a4b8aa ("Bump actions/checkout from 4 to 6") updated `build-firmware.yml` and `release.yml` but left the composite action on v4 — even though all three referenced `actions/checkout@v4` at that moment. The same happened with b7b427e for `download-artifact`.

This is a known Dependabot limitation, reported for exactly this layout and closed as not planned:

- https://github.com/dependabot/dependabot-core/issues/7495
- https://github.com/dependabot/dependabot-core/issues/6704
- https://github.com/dependabot/dependabot-core/issues/6936

## Change

Move both to the majors already in use by the workflows. Node runtimes verified from each action's own `action.yml` `using:` field:

| action | before | after |
| --- | --- | --- |
| `actions/checkout` | v4 (`node20`) | v6 (`node24`) |
| `actions/download-artifact` | v4 (`node20`) | v8 (`node24`) |

All inputs used here (`path`, `repository`, `submodules`, `ref`, `pattern`, `merge-multiple`) are still supported in the new majors.

## Verification

Built on a fork using the `pull_request` event (the same event this PR uses):

- `Build all firmwares`: all 19 build jobs plus `Check size` green
- Node 20 deprecation annotations on `Build all firmwares`: **19 → 0**

## Optional follow-up (not included in this PR)

To stop this from silently recurring, `.github/dependabot.yml` could cover the composite action directories:

```yaml
  - package-ecosystem: "github-actions"
    directories:
      - "/.github/actions/checkout-qmk_firmware"
      - "/.github/actions/release-archive"
    schedule:
      interval: "weekly"
```

I have not verified this config myself, so I left it out of this PR. Note that globstar paths have been reported to produce duplicate PRs (https://github.com/dependabot/dependabot-core/issues/10884), so listing the directories explicitly looks safer than `/.github/actions/*`.
