### PR TITLE
fix: port rp2040 support for keyball39

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball39/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball39/config.h
@@ -42,6 +42,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define SPLIT_TRANSACTION_IDS_KB KEYBALL_GET_INFO, KEYBALL_GET_MOTION, KEYBALL_SET_CPI
 
+// RP2040 controller conversion needs the Pro Micro SPI pins used by the sensor.
+#ifdef MCU_RP
+#    define SPI_DRIVER SPID0
+#    define SPI_SCK_PIN B1
+#    define SPI_MOSI_PIN B2
+#    define SPI_MISO_PIN B3
+#    define SPLIT_HAND_MATRIX_GRID_LOW_IS_LEFT
+#endif
+
 // RGB LED settings
 #define WS2812_DI_PIN       D3
 #ifdef RGBLIGHT_ENABLE


### PR DESCRIPTION
This ports the rp2040 fix made in https://github.com/Yowkees/keyball/pull/870 but for the keyball39. The original fix only included keyball44 since that's what they had to test with.

I just assembled the keyball39 using a pair of Elite Pi microcontrollers and used this patch to build the firmware on my board:

```bash
make SKIP_GIT=yes CONVERT_TO=elite_pi keyball/keyball39:via
```