### PR TITLE
fix: keyboard hanging at boot on QMK 0.26+ with ARM controllers

### DIFF
--- a/qmk_firmware/keyboards/keyball/drivers/pmw3360/pmw3360.c
+++ b/qmk_firmware/keyboards/keyball/drivers/pmw3360/pmw3360.c
@@ -140,7 +140,6 @@ bool pmw3360_init(void) {
     spi_init();
     setPinOutput(PMW3360_NCS_PIN);
     // reboot
-    pmw3360_spi_start();
     pmw3360_reg_write(pmw3360_Power_Up_Reset, 0x5a);
     wait_ms(50);
     // read five registers of motion and discard those values
@@ -154,7 +153,6 @@ bool pmw3360_init(void) {
     // check product ID and revision ID
     uint8_t pid = pmw3360_reg_read(pmw3360_Product_ID);
     uint8_t rev = pmw3360_reg_read(pmw3360_Revision_ID);
-    spi_stop();
     return pid == 0x42 && rev == 0x01;
 }
 


### PR DESCRIPTION
Hey there,

I just recently finished building a Keyball39 using Elite-Pi microcontrollers.

The docs [here](https://github.com/Yowkees/keyball/blob/main/qmk_firmware/keyboards/keyball/readme.md#how-to-build) indicate that the firmware is known to work with QMK `0.22.14`.

While upgrading QMK versions, I found that compiling against QMK >= `0.26` introduced an issue where the OLED freezes on its first frame, and the keys and trackball do nothing.

The cause is in `pmw3360_init()`:
- It calls `pmw3360_spi_start()` (which calls `spi_start()`) explicitly
- then immediately calls `pmw3360_reg_write()` (which _also_ calls `pmw3360_spi_start()`, therefore also calling `spi_start()`)

qmk/qmk_firmware#23439 added a mutex to `spi_start()` on ARM controllers like the RP2040 (QMK runs these on ChibiOS), and it isn't recursive, so since that change `pmw3360_init()` deadlocks on the second call.

The outer `spi_start()`/`spi_stop()` pair wasn't doing anything, since every register read and write already opens and closes the bus on its own. So this PR just deletes those two lines.

Tested on a Keyball39 with Elite-Pi controllers:

- QMK `0.22.14`: works with and without the patch (i.e. backwards compatible)
- QMK `0.26.11`: hangs without this patch, works with it
- QMK `0.28.0`: hangs without this patch, works with it, including split with either half as master

AVR (Pro Micro) builds aren't affected. QMK's AVR `spi_start()` has no mutex, so the nested call was already a no-op there. I haven't tested it on AVR hardware, though.
